### PR TITLE
Made a few changes

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,11 +1,11 @@
 [Adblock]
-! Version: 20181103
+! Version: 201811131
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
-! Last modified: 3rd of November 2018
-! Expires: 7 days (update frequency)
+! Last modified: 13th of November 2018
+! Expires: 7 days
 ! Homepage: https://github.com/finnish-easylist-addition/finnish-easylist-addition
-! License: http://unlicense.org/
+! License: https://unlicense.org/
 !
 ! Please report any issues at:
 ! https://github.com/finnish-easylist-addition/finnish-easylist-addition/issues
@@ -127,7 +127,6 @@ tyda.se#@#DIV[class*="advert"]
 ##DIV[id="ads-sidebar-top"]
 ##DIV[id="ads-left-top"]
 ##DIV[id^="ads-content-bottom"]
-##a[href*="casino"]>img
 ##div[class="ad-wrapper"]
 ##td[class="adbanner"]
 ##div[id="adCarousel"]
@@ -145,7 +144,6 @@ tyda.se#@#DIV[class*="advert"]
 ##DIV[id="cookieprivacy"]
 ##DIV[class*="pea_cook_wrapper"]
 
-aamulehti.fi##DIV[class="adContainer nobg opaque"]
 aamulehti.fi##div.adContainer
 aamulehti.fi##div[class="sidebar frontpageBottom"]
 aamulehti.fi##div[class="mainColRight is_stuck"]>div>div>iframe
@@ -189,8 +187,6 @@ artparquet.ru
 bomber.fi##a[onclick^="countAdClick"]
 network.bazaarvoice.com/st.gif
 x.bidswitch.net/*?ssp=teads
-bild.de##DIV[class="fullbanner"]
-bild.de##DIV[class="skyscraper"]
 bike.fi##DIV#newsletter-dialog[class="open"]
 bike.fi##DIV[class="banner panorama"]
 bike.fi##DIV[class="banner banner"]
@@ -246,17 +242,14 @@ hbl.fi##ksf-adblockers
 hastens.com##div[class="footer-cookies"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[class*="lyads"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[id="ensNotifyBanner"][class="ensNotifyBanner"]
-hs.fi##DIV[class="area ad-container"]
 hs.fi##DIV[class*="ad-container"]
 hs.fi##DIV[class*="-ad-block"]
 hs.fi##DIV#story-package-container[class="story-package"]
 hs.fi/webstatic/images/clear1x1.gif
 hs.fi##DIV[class="corporate-footer"]
 hs.fi##DIV[class="embedded-ad ad-small pull-back"]
-hs.fi##DIV#multi-ad-area[class="full-width-area"]
 hs.fi##DIV[id="javascript-disabled-error"]
 hs.fi##DIV[class="tracking-pixel"]
-hs.fi/tilasto/artikkeli/
 hs.fi##DIV[id="outside-ads"]
 hs.fi##div[id="order-campaign-element"]
 hs.fi##div[class="for-no-subscription"]
@@ -264,9 +257,7 @@ hs.fi##div[id="christmas-campaign-element"]
 hs.fi##div[id="oikotie_asunnot_box_iframe"]
 hs.fi##div[id="multi-ad-area"]
 hs.fi##div[id="hsonfb-links"]
-hs.fi##div[class="tracking-pixel"]
 hs.fi/tilasto/artikkeli
-hs.fi/sivulaskuri
 hs.fi/stats
 is.fi##iframe[data-original*="vg.is.fi"]
 hifimaailma.fi##div[id="secondary"]
@@ -311,7 +302,6 @@ iltalehti.fi##DIV[class="plus-promo-bottom"]
 iltalehti.fi##h2[class="vinjetti"]+div
 iltalehti.fi##div[class*="kp-share-area"]
 iltalehti.fi##div[id="content"]>a[id="header"]
-iltalehti.fi##div[class="ALMACR-container"]
 iltalehti.fi##iframe[src*="/ads/"]
 iltalehti.fi##a[href*="rantapallo.fi"]
 iltalehti.fi##div[class="banner-container"]
@@ -352,7 +342,6 @@ is.fi##DIV[data-html-asset-id="82"]
 is.fi##DIV[data-html-asset-id="943"]
 is.fi##DIV[data-html-asset-id="109"]
 is.fi##table[id="kumppaneiden-tarjoukset"]
-is.fi##iframe[data-original*="vg.is.fi"]
 is.fi##iframe[data-original*="kampanjat/promo/nostot"]
 is.fi##DIV[class="supersaa-widget-container"]
 is.fi##article[class*="is-advertorial"]
@@ -386,13 +375,11 @@ kuljetusnet.fi##div[class*="banner"]
 knowed.ru
 krasivoe-kino.com
 kuopionkirppari.fi##DIV[class*="banner"]
-lifehacker.com##div[class*="ad-"]
 loimaanlehti.fi##div[class*="pro_ad_adzone"]
 loimaanlehti.fi##div[class*="art-sidebar2"]>div[id*="black-studio-tinymce"]
 maalampofoorumi.fi##DIV[id="sponsor"]
 matkaendurot.net/images/*banner
 matkaendurot.net##SPAN[id="banneripaikka"]
-matkaendurot.net##SPAN[id="banneripaikka2"]
 matkaendurot.net##DIV[id="logodesc"]>table>tbody>tr>td:first-of-type
 mbnet.fi##DIV#tyopaikat-joblift--avainpaikat
 mbnet.fi##DIV#topbanner
@@ -414,8 +401,6 @@ mvlehti.net##div[id*="ads-"]
 lansivayla.fi##DIV[class="region region-sidebar-karuselli-ad column sidebar"]
 lansivayla.fi##DIV[class="region region-sidebar-first-bottom column sidebar"]
 leiki.com/
-linkedin.com##div[id="display-ads-region"]
-linkedin.com##section[class*="ad-banner"]
 ads.linkedin.com/
 live.community.bmw-motorrad.com
 mediagraph.com/*/log.gif
@@ -454,7 +439,6 @@ mtv.fi##DIV[class="banner banner-jattiboksi"]
 mtv.fi##section[class="ad"]
 mtv.fi##IFRAME#hz-unit-etusivu
 mtv.fi/static/javascripts/external-js/*.js
-mtv.fi/.*smartbanner.js
 st.mtv.fi/static/html/cookie-notification
 mtv.fi##div[class="leaderboard"]
 mtv.fi##DIV[class*="ad-container"]
@@ -522,10 +506,6 @@ snoobi.com/snoop
 ! snstatic.fi/webstatic/*/desktop-all.js
 sporg.ru
 spy-sts.com
-stackoverflowproxy.
-stackoverflow.com##DIV#hireme[class="orange looking tagged"]
-stackoverflow.com##DIV#hireme[class="blue near-you tagged"]
-stackoverflow.com##DIV#newsletter-ad
 stream.almamedia.fi/mp/salsabanner
 meta.almamedia.io/v1/text?
 survey.interquest.fi/
@@ -534,7 +514,6 @@ suomela.fi##div[class*="simplemodal"]
 suomela.fi##div[class*="banner"]
 suomif1.com##div[class*="-ad"]
 suomif1.com##div[class*="minilanding"]
-suomi24-static.fi/js/spring.js
 suomi24.fi##div[class^="ad"]
 suomi24.fi##li[class="ad"]
 suomi24.fi##div[class*="ad-frontpage"]
@@ -557,8 +536,6 @@ taloussanomat.fi##div[class*="centeredAd"]
 taloussanomat.fi##div[id*="PromoContainer"]
 taloussanomat.fi##div[id="iltasanomatPromo"]
 taloussanomat.fi##div[id="hsframeContainer"]
-taloussanomat.fi##div[id="articleNavigation"]
-taloussanomat.fi/js/spring.js
 taloussanomat.fi##div[id*="adTop"]
 itviikko.fi,taloussanomat.fi##DIV[class="readAlso"]
 talouselama.fi##DIV[class="adDisclaimer beforeAd"]
@@ -640,7 +617,6 @@ xracing.fi/tiedostot/
 wpengine.netdna-ssl.com/*/moottori/*/popup*.js
 zakreativ.ru
 
-horizonsunlimited.com##DIV[class="advert-here"]
 horizonsunlimited.com##a[href*="9mmff.com"]
 
 ||24counter.com
@@ -766,7 +742,6 @@ giosg.com$domain=etuovi.com
 ||pixel.mathtag.com
 ||polarmobile.com
 ||rubiconproject.com$third-party
-||sn.sanoma.fi/js/sccm/sccm.js
 ||nova.collect.igodigital.com/*/track_page
 ||nativeads.com$third-party
 ||spotxchange.com
@@ -853,7 +828,6 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 
 @@adserver.adtech.de$domain=hs.fi|iltasanomat.fi|is.fi
 @@ad.360yield.com$domain=hs.fi|iltasanomat.fi|is.fi
-@@track.adform.net$domain=hs.fi|iltasanomat.fi|is.fi
 @@doubleclick.net$domain=hs.fi|iltasanomat.fi|is.fi
 @@adform.net$domain=hs.fi|iltasanomat.fi|is.fi
 
@@ -905,7 +879,6 @@ ads-manual*.nelonenmedia.fi/ads/
 www.mtvuutiset.fi##div.ad-container.component
 www.mtvuutiset.fi###leaderboard-2
 www.mtvuutiset.fi##.component-adincontent.component
-www.mtvuutiset.fi##.component-ad-leiki.component > .component-adincontent.component > .ad-container.banner
 www.mtvuutiset.fi##.leaderboard-1.leaderboard
 
 ! iotech banners

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,9 +1,9 @@
 [Adblock]
-! Version: 201811131
+! Version: 201811132
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
 ! Last modified: 13th of November 2018
-! Expires: 7 days
+! Expires: 4 days
 ! Homepage: https://github.com/finnish-easylist-addition/finnish-easylist-addition
 ! License: https://unlicense.org/
 !
@@ -785,7 +785,6 @@ spring-tns.net$third-party
 ||celtra.com$third-party
 ||madsone.com$third-party
 ||yabidos.com
-||platform.linkedin.com
 ||adten.eu
 ||w55c.net
 ||media.vuokraovi.com$third-party
@@ -806,7 +805,6 @@ spring-tns.net$third-party
 ||euroads.fi
 ||vihreat.fi/?q=node/*/stats/impression
 
-
 ! kaleva.fi
 carousel-prod-kaleva-fi.s3.amazonaws.com
 kaleva.fi##div[id^="mainokset-"]
@@ -817,29 +815,6 @@ kaleva.fi/static/common/js/spring
 kaleva.fi/static/rkfi/assets/js-min/ads
 kaleva.fi##div[class*="--juttusivu-markkinointi"]
 kaleva.fi##DIV[id="kaleva-cookie-consent"]
-
-! To enable iltasanomat.fi etc. videos
-@@||adserver.adtech.de/?adrawdata/$object-subrequest,domain=groovefm.fi|hs.fi|iltasanomat.fi|is.fi|istv.fi|jimtv.fi|livtv.fi|loop.fi|metrohelsinki.fi|nelonen.fi|nelonenpro.fi|nyt.fi|radioaalto.fi|radiorock.fi|radiosuomipop.fi|ruokala.net|ruutu.fi|liiga.fi
-! @@||adserver.adtech.de/?advideo/$domain=groovefm.fi|hs.fi|istv.fi|jimtv.fi|livtv.fi|loop.fi|metrohelsinki.fi|nelonen.fi|nelonenpro.fi|nyt.fi|radioaalto.fi|radiorock.fi|radiosuomipop.fi|ruokala.net|ruutu.fi|liiga.fi|viasatsport.fi
-@@adserver.adtech.de/crossdomain.xml$domain=groovefm.fi|hs.fi|iltasanomat.fi|is.fi|istv.fi|jimtv.fi|livtv.fi|loop.fi|metrohelsinki.fi|nelonen.fi|nelonenpro.fi|nyt.fi|radioaalto.fi|radiorock.fi|radiosuomipop.fi|ruokala.net|ruutu.fi|liiga.fi
-@@||ads-pmd.nelonenmedia.fi/ads/*.mp4
-@@fwmrm.net$domain=hs.fi|iltasanomat.fi|is.fi
-
-
-@@adserver.adtech.de$domain=hs.fi|iltasanomat.fi|is.fi
-@@ad.360yield.com$domain=hs.fi|iltasanomat.fi|is.fi
-@@doubleclick.net$domain=hs.fi|iltasanomat.fi|is.fi
-@@adform.net$domain=hs.fi|iltasanomat.fi|is.fi
-
-@@nexus.ensighten.com/*/servercomponent.php$domain=tallinksilja.fi
-
-@@||ko.snstatic.fi/static/is-paivan-lehti/*
-@@||ko.snstatic.fi/static/urheilusanomat/*
-@@||iltasanomat.fi/kampanjat/promo/nostot/etusivu-sarjakuvat/*
-@@||iltasanomat.fi/kampanjat/promo/nostot/extra/*
-@@||is.fi/kampanjat/promo/nostot/etusivu-sarjakuvat/*
-@@||is.fi/kampanjat/promo/nostot/extra/*
-@@||is.fi/kampanjat/suomi100/is-logo-*
 
 ! mtv videoihin toimintavarmuutta
 @@||st.mtv.fi/static/javascripts/external-js/detectmobilebrowser.js?
@@ -883,3 +858,10 @@ www.mtvuutiset.fi##.leaderboard-1.leaderboard
 
 ! iotech banners
 ||www.io-tech.fi/bnr/$image
+
+! Media unbreakers
+@@||fwmrm.net/ad/$script,domain=ruutu.fi|dplay.fi
+@@||www.foxplay.fi/compiled/js/ads.js$script
+||nelonenmedia.fi/ads/$media,domain=ruutu.fi
+||dniadops-a.akamaihd.net/video-assets/$media,domain=www.dplay.fi
+||ads-spotgate02.nelonenmedia.fi^$media,domain=www.is.fi


### PR DESCRIPTION
Greetings from Norway / Hälsningar ifrån Norge. It's great to see that someone decided to continue work on a Finnish adblock list, so that an entire nation wouldn't be left without an adblock list.

As I have experience from maintaining the Norwegian list (*Dandelion Sprouts norske filtre*), I've attempted to make a few changes to help streamline and improve the list. In particular, I've removed some entries whose relevance to Finland were low (e.g. Bild.de, LinkedIn, Stack Overflow), ran the list through https://arestwo.org/famlam/redundantRuleChecker.html, and brushed up the metadata values.

I also added an extra number to the end of the version numbers, in case you were to want to edit the list multiple times during one day. 201811131 would be the 1st version from that day, 201811132 would the 2nd version, and so on.

The *Redundant Rule Checker* tool also proposes replacing `##div[id="` entries with `##div#` ones, but if you're new to the world of adblock list writing, I'll let you get used to more important and ordinary things first at your own pace.

As a last note: There's also another and very thorough Finnish list from 2014 called [Wiltteri](https://raw.githubusercontent.com/wiltteri/wiltteri.txt/master/wiltteri.txt). It's too old by now to be used in normal circumstances, but you could possibly be able to draw some inspiration from it or borrow some entries from it.

