### PR TITLE
viafree.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -836,3 +836,10 @@ mtv.fi##.mtv-player-ad-container
 ! https://github.com/finnish-easylist-addition/finnish-easylist-addition/issues/14#issuecomment-438683057
 ! https://github.com/finnish-easylist-addition/finnish-easylist-addition/issues/12#issuecomment-438682037
 ! ||damoh.katsomo.fi/*$media,redirect=noopmp3-0.1s,domain=mtvuutiset.fi|mtv.fi
+
+! To make viafree.fi videos to work withoud ads
+@@||mssl.fwmrm.net/p/MTG_Brightcove_HTML5/AdManager.js$script,domain=www.viafree.fi
+@@||fwmrm.net/ad/$xmlhttprequest,domain=www.viafree.fi
+@@||playapi.mtgx.tv/$xmlhttprequest,domain=www.viafree.fi
+@@||fwmrm.net/ad/$script,domain=www.viafree.fi
+||freewheel-mtgx-tv.akamaized.net/$media,domain=www.viafree.fi


### PR DESCRIPTION
I made filters for videos of this site. A nice load of filters was needed.... :D

Here is a sample url:
https://www.viafree.fi/ohjelmat/dokumentit/sotarikokset/kausi-1/jakso-6

However there are small "hiccups". Videos load without ads but there is a small quick flashing of "video cannot be loaded" text that however goes away quickly. That text flashes every time the sites tries to load ads (the beginning of the video and during commercial breaks). But this will work anyway.