### PR TITLE
a general whitelist filter for Nelonen Media

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -819,12 +819,13 @@ mtvuutiset.fi##.ad_fadein
 ||www.io-tech.fi/bnr/$image
 
 ! Media unbreakers
-@@||fwmrm.net/ad/$script,domain=ruutu.fi|dplay.fi|nelonen.fi
+@@||fwmrm.net/ad/$script,domain=dplay.fi
 @@||www.foxplay.fi/compiled/js/ads.js$script
 ||nelonenmedia.fi/ads/$media,domain=ruutu.fi
 ||dniadops-a.akamaihd.net/video-assets/$media,domain=www.dplay.fi
 ||ads-spotgate02.nelonenmedia.fi^$media,domain=www.is.fi
 @@||v.fwmrm.net/ad/g/*_Supla_Audio_HTML5_Live$script
+@@||fwmrm.net/ad/*Nelonen_Web_HTML5_Live$script
 
 ! Prevent clicking video ads on mtvuutiset.fi and mtv.fi
 mtvuutiset.fi##.mtv-player-ad-container


### PR DESCRIPTION
Hi!

I noticed that I got video loading blocked on these addresses:
`https://www.hs.fi/ulkomaat/art-2000005899876.html`
`https://www.is.fi/ulkomaat/art-2000005900070.html`
`https://www.loop.fi/#!/post/575a917182d2770300df20ed`
`https://www.helmiradio.fi/#!/post/5bc46dc8e71e32040057e3aa`
`https://www.radioaalto.fi/#!/post/594a5ae263f08304009926ad`
`https://www.radiorock.fi/#!/post/5714bf2b8fd9330300d44494`
`https://www.radiosuomipop.fi/#!/post/545b3d0118242702001890b6`

So I came to conclusion that it would be better to make a general filter for all those sites - or for Nelonen Media. Ubo has some built-in filters but ABP users are not in that good position.

That general filter will work for any site under Nelonen Media since they use that same script everywhere. Also it's possible to embed ruutu.fi short videos to other sites so that's another reason why universal filter is needed. :)

For example this video is possible to embed on other sites:
`https://www.ruutu.fi/video/3323495` (when the video is opened there is "jaa" (share) button on the upper right corner of the video.

Dplay.fi (Discovery Networks Finland) does not need a general filter at this moment as far as I know. :)