### PR TITLE
Unbreaking chat function on moi.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -769,8 +769,8 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 ! mtv videoihin toimintavarmuutta
 @@||st.mtv.fi/static/javascripts/external-js/detectmobilebrowser.js?
 
-! Sallii chatin näkymisen Telia Omilla sivuilla
-@@-tracking.js?$domain=telia.fi
+! Unbreaks chat function
+@@-tracking.js?$domain=telia.fi|moi.fi
 
 ! Exceptions
 @@||veho.fi/huolto/huollon-palvelut/huollon-ajanvaraus/$document


### PR DESCRIPTION
Easyprivacy breaks chat function not only on telia.fi but also on moi.fi.... Added fix for that. Also translated comment into English.