### PR TITLE
ad placeholder remnant (karjalainen.fi)

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -331,6 +331,7 @@ kansalainen.fi##div[id^="ads"]
 kansalainen.fi##div[id="text-html-widget-5"]
 kansanuutiset.fi##A[href="http://www.autonvaraosastore.fi/"]
 kansanuutiset.fi##div[class*="intextad"]
+karjalainen.fi##center
 kansi.a-lehdet.fi/spring.js
 adslm.a-lehdet.fi/www/delivery/ 
 kauppalehti.fi/blank.gif


### PR DESCRIPTION
Empty "ad begins - ad ends" section left by blocked ads, inside an article.

Sample page: https://www.karjalainen.fi/uutiset/uutis-alueet/ulkomaat/item/201184