### PR TITLE
Added adblocking for more MTV Oy owned domains

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -821,10 +821,9 @@ mtvuutiset.fi##.ad_fadein
 @@||v.fwmrm.net/ad/g/*_Supla_Audio_HTML5_Live$script
 @@||fwmrm.net/ad/*Nelonen_Web_HTML5_Live$script
 
-! Prevent clicking video ads on mtvuutiset.fi and mtv.fi
-mtvuutiset.fi##.mtv-player-ad-container
-mtv.fi##.mtv-player-ad-container
-||damoh.katsomo.fi/*$image,domain=mtvuutiset.fi|mtv.fi
+! Prevent clicking video ads on MTV Oy
+mtvuutiset.fi,mtv.fi,suomiareena.fi,www.studio55.fi,lumijapyry.fi##.mtv-player-ad-container
+||damoh.katsomo.fi/*$image,domain=mtvuutiset.fi|mtv.fi|suomiareena.fi|www.studio55.fi|lumijapyry.fi
 ||cloudfront.net/creatives/assets/$image,domain=mtvuutiset.fi
 
 ! To make viafree.fi videos to work without ads


### PR DESCRIPTION
These domains added:

`https://suomiareena.fi/`
`https://www.studio55.fi/`
`https://lumijapyry.fi/`