### PR TITLE
aamulehti.fi adblocking complaint

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -149,6 +149,7 @@ aamulehti.fi##div[class="sidebar frontpageBottom"]
 aamulehti.fi##div[class="mainColRight is_stuck"]>div>div>iframe
 aamulehti.fi/*/spring.js
 aamulehti.fi/*/alma_init_cjs.js
+aamulehti.fi##.huCagr.sc-fFTYTi
 aamuset.fi##DIV#block-views-etusivukaruselli-block
 aamuset.fi##DIV#block-views-mainoskaruselli-block
 aamuset.fi##DIV[class="adslist"]


### PR DESCRIPTION
This filter blocks adblocking complaint on `aamulehti.fi`. I think it should be blocked as well.