### PR TITLE
uusisuomi.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -553,6 +553,7 @@ uusisuomi.fi##div[id*="AdSpace"]
 uusisuomi.fi##div[class*="google_ad"]
 uusisuomi.fi##div[class*="ad-view"]
 uusisuomi.fi##div[class*="ad_sidebar"]
+uusisuomi.fi###block-us-appnexus-puheevuoro-468-600--2
 uutismaailma.com##DIV[class="top_banner"]
 uutissuora.fi##div[class="td-all-devices"]
 vaalikone.fi/*/preheat


### PR DESCRIPTION
Added a filter to remove a strange ad remnant(?) inside articles.

A sample page: `https://www.uusisuomi.fi/kotimaa/265030-sotatieteiden-tohtori-saara-jantunen-eduskunnan-tiedusteluvaliokunnan-11`

a screenshot:

![](https://images2.imgbox.com/bd/f2/EAEPK3x5_o.png)