### PR TITLE
hs.fi separate ad articles

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -785,6 +785,8 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 @@||adlibris.com/pixel.gif
 @@/pixel.gif$domain=xhamster.com
 @@||uusi.op.fi/$document
+www.hs.fi#@#.mainos
+www.hs.fi#@#.mainokset
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit


### PR DESCRIPTION
At this moment, Finnish Easylist blocks separate ad articles on hs.fi. (A sample: `https://www.hs.fi/mainos/art-2000005901798.html`) (main page: `https://www.hs.fi/aihe/mainokset/`)

I consider those kind of articles legit since they are completely separate and there is nothing that "pops up" and disturbs user as "normal ads" do. You can find those articles even through google search. Articles like that are something that someone would possibly like to read.

I added whitelist filters to unblock those.