### PR TITLE
mobiili.fi - fixed a minor breakage and unblocked ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -369,6 +369,12 @@ mobiili.fi##div[class="blogcontent"]>p:first-of-type
 mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(1)
 mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(2)
 mobiili.fi##div[id="fullcolumn"]>p:first-of-type
+mobiili.fi###text-67 > .textwidget
+mobiili.fi##.single-content-all > p:nth-of-type(1)
+mobiili.fi##p:nth-of-type(8)
+mobiili.fi##.maincontent.blogpost > p:nth-of-type(1)
+mobiili.fi##.article_ad_1
+mobiili.fi##.article_ad_2
 mvlehti.net##a[href*="affmore.com"]
 mvlehti.net##a[href*="redirect"]
 mvlehti.net##a[href*="honestpartners.com"]
@@ -785,6 +791,7 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 @@||adlibris.com/pixel.gif
 @@/pixel.gif$domain=xhamster.com
 @@||uusi.op.fi/$document
+mobiili.fi#@#.header_ad
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit


### PR DESCRIPTION
Ads: on right bar there were unblocked ads (images) and before and after article there were some text ads. Also before the comments section there were empty ad placeholders.

Minor breakage: when Easylist is enabled the title of an article goes "too up" and touches the top bar and some elements also get hid under it. A whitelist rule I made fixes it and does not bring any ads visible even though it's name might suggest that. :)

A sample link: `https://mobiili.fi/2018/11/20/et-todennakoisesti-tiennyt-tata-kikkaa-nain-saat-android-puhelimesi-tuntumaan-nopeammalta/`

Screenshots:
`https://images2.imgbox.com/b6/9e/NFt9mldj_o.png`
`https://images2.imgbox.com/17/d2/LOhn4EKe_o.png`

(Screenshots are taken before I fixed those other ads)