### PR TITLE
mobiili.fi - fixed some breakages and blocked unlocked ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -364,11 +364,12 @@ metropoli.net##LI[id*="_ad"]
 metropoli.net##a[href*="nordicbet"]
 metropoli.net##LI[class*="-ad"]
 mikrobitti.fi##DIV[id="rosmo"]
-mobiili.fi##div[class="tops-bar"]
 mobiili.fi##div[class="blogcontent"]>p:first-of-type
 mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(1)
-mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(2)
 mobiili.fi##div[id="fullcolumn"]>p:first-of-type
+mobiili.fi###text-67 > .textwidget
+mobiili.fi##.article_ad_1
+mobiili.fi##.article_ad_2
 mvlehti.net##a[href*="affmore.com"]
 mvlehti.net##a[href*="redirect"]
 mvlehti.net##a[href*="honestpartners.com"]
@@ -598,6 +599,7 @@ spring-tns.net$third-party
 ||adsafeprotected.com
 ||adsby.webtraffic.se
 ||adservicemedia.dk$third-party
+||adservicemedia.dk*sub=side*$image,domain=mobiili.fi,important
 ||adservinginternational.com
 ||adspeed.net
 ||adsrvr.org$third-party
@@ -785,6 +787,8 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 @@||adlibris.com/pixel.gif
 @@/pixel.gif$domain=xhamster.com
 @@||uusi.op.fi/$document
+mobiili.fi#@#.header_ad
+@@||adservicemedia.dk/$image,domain=mobiili.fi
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit


### PR DESCRIPTION
1. Breakage: when Easylist is enabled the title of an article goes "too up" and touches the top bar and some elements also get hid under it. A whitelist rule I made fixes it and does not bring any ads visible even though it's name might suggest that. :)

A sample link: `https://mobiili.fi/2018/11/20/et-todennakoisesti-tiennyt-tata-kikkaa-nain-saat-android-puhelimesi-tuntumaan-nopeammalta/`

Screenshots:
![](https://images2.imgbox.com/b6/9e/NFt9mldj_o.png)
![](https://images2.imgbox.com/17/d2/LOhn4EKe_o.png)

(Screenshots are taken before I fixed those other ads)

fix filter: `mobiili.fi#@#.header_ad`

2. Breakage: filters prevented images from loading on separate ad articles that are legit since they are separate articles that someone could want to read. They however loaded their pictures from ad servers.

This filter fixed images on (ad) articles:
`@@||adservicemedia.dk/$image,domain=mobiili.fi`

This filter makes sure that this ad server does not load any other pictures but those that are supposed to be in those ad articles:
`||adservicemedia.dk*sub=side*$image,domain=mobiili.fi,important`

("important" makes it impossible for any whitelist rule to override it)

a couple of ad articles:
`https://mobiili.fi/2018/10/19/voita-1-029-euron-samsung-galaxy-note9-telialta-osallistu-arvontaan-tasta/`
`https://mobiili.fi/2018/01/12/elisa-kirja-ilmainen/`

3. Unblocked ads:

`mobiili.fi###text-67 > .textwidget`
`mobiili.fi##.article_ad_1`
`mobiili.fi##.article_ad_2`

Those are ads on the right side of the page and empty ad placeholders before the comments.

Note: there are still some text ads before and after the article but I could not block them in a reliable way since they seemingly used the same syntax and numbering as normal paragraphs which caused those filters to block paragraphs from articles in some cases...

I'll probably try later again to check them. Just making these other changes first.

4. A couple of obsolete filters removed

These filters don't load when browsing mobiili.fi so I took them out.

`mobiili.fi##div[class="tops-bar"]`
`mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(2)`