### PR TITLE
aamulehti.fi - content moves slowly under to the blue bar

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -150,6 +150,7 @@ aamulehti.fi/*/spring.js
 aamulehti.fi/*/alma_init_cjs.js
 aamulehti.fi##.huCagr.sc-fFTYTi
 aamulehti.fi##.fKjNmg.sc-kDhYZr
+aamulehti.fi##.parade-ad.ad
 aamuset.fi##DIV#block-views-etusivukaruselli-block
 aamuset.fi##DIV#block-views-mainoskaruselli-block
 aamuset.fi##DIV[class="adslist"]


### PR DESCRIPTION
It can fixed with this:

`aamulehti.fi##.parade-ad.ad`