### PR TITLE
telsu.fi duunitori-box

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -516,6 +516,7 @@ telsu.fi##a[href*="duunitori.fi"]
 telsu.fi##div[class="duunibox"]
 telsu.fi##.as.city_top
 telsu.fi###prebid_top > .box_dt
+telsu.fi###prebid_bottom > .box_dt
 /images/Zero_EN.gif$domain=tracking.dpd.de,image
 thenextweb.com##div[class^="modal"]
 thenextweb.com##ul[class="articleShare-buttons"]

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -515,6 +515,7 @@ tekniikkatalous.fi,marmai.fi,tivi.fi##div[class*="articlead"]
 telsu.fi##a[href*="duunitori.fi"]
 telsu.fi##div[class="duunibox"]
 telsu.fi##.as.city_top
+telsu.fi###prebid_top > .box_dt
 /images/Zero_EN.gif$domain=tracking.dpd.de,image
 thenextweb.com##div[class^="modal"]
 thenextweb.com##ul[class="articleShare-buttons"]


### PR DESCRIPTION
Sometimes when changing filter settings on telsu.fi, duunitori ad will display. This is a filter to block it.