### PR TITLE
is.fi adcontainers

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -885,6 +885,7 @@ ylilauta.org##DIV[class^="center"]
 
 ! ad containers
 satakunnankansa.fi,valkeakoskensanomat.fi,nokianuutiset.fi,janakkalansanomat.fi,kmvlehti.fi,jamsanseutu.fi,suurkeuruu.fi,kankaanpaanseutu.fi,rannikkoseutu.fi,tyrvaansanomat.fi,merikarvialehti.fi,sydansatakunta.fi##.parade-ad.ad
+www.is.fi##div.sadblob-loading
 
 ! Alypaa.com unbreak and block ads in a better way
 @@||sestatic.net^$image,domain=alypaa.com


### PR DESCRIPTION
It can be found there, those lines:

<img width="1034" alt="screen shot 2018-12-08 at 11 19 34" src="https://user-images.githubusercontent.com/5832930/49684310-29bf8800-fadb-11e8-8f90-60e11babf389.png">
