### PR TITLE
Unbreak loading of a subcategory on Yle Areena

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -840,6 +840,9 @@ www.hs.fi#@#.mainokset
 ! unbreak apotek1.no
 apotek1.no#@#DIV[class*="ad-element"]
 
+! unbreak loading of a subcategory
+@@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=areena.yle.fi
+
 ! MuroBBS - Hintaopas
 murobbs.muropaketti.com###hintaopas_top_product_block
 

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,8 +1,8 @@
 [Adblock Plus 2.0]
-! Version: 201812061
+! Version: 201812171
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
-! Last modified: 6th of December 2018
+! Last modified: 17th of December 2018
 ! Expires: 4 days
 ! Homepage: https://github.com/finnish-easylist-addition/finnish-easylist-addition
 ! License: https://unlicense.org/


### PR DESCRIPTION
When changing a subcategory on Yle Areena `https://areena.yle.fi/tv/ohjelmat/ajankohtaisohjelmat?t=suosituimmat` there will be a neverending loading. Subcategories load only if the page is refreshed and It needs to be done every time again. This fixes it so that subcategories load properly without page refreshing.