### PR TITLE
www.ess.fi unbreak lue seuraavaksi (read next) section

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -845,6 +845,10 @@ apotek1.no#@#DIV[class*="ad-element"]
 ! unbreak loading of a subcategory
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=areena.yle.fi
 
+! unbreak "lue seuraavaksi" (read next) section
+! broken by Easyprivacy
+@@||scdn.cxense.com/cx.js$script,domain=www.ess.fi
+
 ! MuroBBS - Hintaopas
 murobbs.muropaketti.com###hintaopas_top_product_block
 

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -846,8 +846,9 @@ apotek1.no#@#DIV[class*="ad-element"]
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=areena.yle.fi
 
 ! unbreak "lue seuraavaksi" (read next) section
-! broken by Easyprivacy
+! broken by Easyprivacy & Fanboy's Annoyance List
 @@||scdn.cxense.com/cx.js$script,domain=www.ess.fi
+@@||content-thumbnail.cxpublic.com$image,domain=www.ess.fi
 
 ! MuroBBS - Hintaopas
 murobbs.muropaketti.com###hintaopas_top_product_block


### PR DESCRIPTION
Easyprivacy breaks that section. Here is a fix.

Sample site: `https://www.ess.fi/uutiset/paijathame/art2506516`

Screenshot:

![read next broken](https://user-images.githubusercontent.com/17256841/50180154-8a3b9a00-0311-11e9-8756-fe1c0e5e2c6b.png)

It's on the right side of the page, almost at the bottom.

It will usually appear as the page is scrolled down.