### PR TITLE
Unbreak images inside embedded tweets on HS.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -845,6 +845,9 @@ apotek1.no#@#DIV[class*="ad-element"]
 ! unbreak loading of a subcategory
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=areena.yle.fi
 
+! unbreak images inside embedded tweets
+@@||pbs.twimg.com/ad_img/$image,domain=embed.is.fi
+
 ! MuroBBS - Hintaopas
 murobbs.muropaketti.com###hintaopas_top_product_block
 


### PR DESCRIPTION
`https://www.hs.fi/urheilu/art-2000005940367.html` - a sample page

Problem is caused by Easylist.