### PR TITLE
riemurasia.net - ad urls

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -448,6 +448,8 @@ static.sanoma.fi/weba/js/ls/zig.js
 dco-de.sanoma.fi/ussr-ts/sputnik
 ridemedia.fi/aspbanner
 riemurasia.net##div[id*="MTQyM"]
+riemurasia.net##[href^="https://clk.tradedoubler.com/click"]
+riemurasia.net##[href^="http://pizza-online.fi/tt/index.php"]
 sat.sanoma.fi/js
 sat.sanoma.fi/sat
 satakunnankansa.fi##DIV[class="s-ryhma-carousel-wrapper"]


### PR DESCRIPTION
Can be found between "satunnainen media" and "seuraava" buttons. A sample: `https://www.riemurasia.net/kuva/Neropatti-tankkaamassa/216601` - ad url changes sometimes. I added all the ones I encountered.