### PR TITLE
Unbreak embedded tweets in some cases - hs.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -780,6 +780,9 @@ mobiili.fi#@#.header_ad
 ! Unbreak radiot.fi
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=www.radiot.fi
 
+! Unbreak embedded tweets on some cases
+@@||cdn.krxd.net/*$script,domain=www.hs.fi
+
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit
 huuto.net##div.grid-element-container-hintaseuranta.grid-element-container

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -782,6 +782,7 @@ mobiili.fi#@#.header_ad
 
 ! Unbreak embedded tweets on some cases
 @@||cdn.krxd.net/*$script,domain=www.hs.fi
+@@||acdn.adnxs.com/*$script,domain=www.hs.fi
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -780,9 +780,19 @@ mobiili.fi#@#.header_ad
 ! Unbreak radiot.fi
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=www.radiot.fi
 
-! Unbreak embedded tweets on some cases
+! Unbreak embedded objects in some cases
 @@||cdn.krxd.net/*$script,domain=www.hs.fi
 @@||acdn.adnxs.com/*$script,domain=www.hs.fi
+@@||mab.chartbeat.com/mab_strategy/headline_testing/get_strategy/*$xmlhttprequest,domain=www.hs.fi
+@@||tags.tiqcdn.com/utag/sanoma-fi/hs-fi/prod/*$script,domain=www.hs.fi
+@@||krxd.net/*$script,domain=www.hs.fi
+@@||cdn.krxd.net/*$subdocument,domain=www.hs.fi
+@@||cdn.brandmetrics.com/*$script,domain=www.hs.fi
+@@||cdn.krxd.net/*$script,domain=cdn.krxd.net
+@@||sn.sanoma.fi/*$script,domain=www.hs.fi
+@@||ib.adnxs.com/*$xmlhttprequest,domain=www.hs.fi
+@@||ping.chartbeat.net/*$image,domain=www.hs.fi
+@@||vendorlist.consensu.org/*$xmlhttprequest,domain=www.hs.fi
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit


### PR DESCRIPTION
Sometimes (caused by Adblock Finland) some embedded elements are not shown. Tweets are a good example of this. I have faced this issue sometimes. I have noticed it especially when I have read 5 articles and I get a notification to subscribe for hs.fi to read more, I can read articles again when I remove cookies etc. However after removing them I have encountered blocked embedded tweets etc.

A sample page: `https://www.hs.fi/kulttuuri/art-2000005941416.html`

Screenshot:

![twitterogelma hs](https://user-images.githubusercontent.com/17256841/50367261-a3e61700-0587-11e9-8af6-56765f308328.png)

That problem did not go away even though I refreshed the page many times. Only after I added this whitelist filter (I tested many before I found the correct one):

`@@||cdn.krxd.net/*$script,domain=www.hs.fi`

This problem goes away for a while also when you disable Adblock, refresh the page, enable it again and refresh the page again. This is not however a fix of course. :)