### PR TITLE
Problem rule concerning mobiili.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -329,7 +329,6 @@ mobiili.fi###text-67 > .textwidget
 mobiili.fi##.article_ad_1
 mobiili.fi##.article_ad_2
 mobiili.fi###header_ad33
-mobiili.fi##.headermob_ad
 mobiili.fi##.singlehinta.header_ad
 mobiili.fi##img[src^="https://impr.adservicemedia.dk/cgi-bin/Services/ImpressionService/Image.pl"]
 mvlehti.net##a[href*="affmore.com"]


### PR DESCRIPTION
Removed a problematic rule that caused the content to go too up on some subpages.

`https://mobiili.fi/puhelimet/`

![mobiili problem](https://user-images.githubusercontent.com/17256841/50744179-588b6400-1229-11e9-960c-3d51f40e0f71.png)

I did not see any ad appearing after removing this rule.