### PR TITLE
Ad on mobiili.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -332,6 +332,7 @@ mobiili.fi###header_ad33
 mobiili.fi##.headermob_ad
 mobiili.fi##.singlehinta.header_ad
 mobiili.fi##img[src^="https://impr.adservicemedia.dk/cgi-bin/Services/ImpressionService/Image.pl"]
+mobiili.fi##.blogcontent > .banner-ad
 mvlehti.net##a[href*="affmore.com"]
 mvlehti.net##a[href*="redirect"]
 mvlehti.net##a[href*="honestpartners.com"]


### PR DESCRIPTION
`https://mobiili.fi/2019/01/06/applen-itunes-sisallot-tulevat-osaksi-samsung-televisioita-televisioihin-tuki-myos-airplay-2lle/` Encountered here after the article.