### PR TITLE
add ads and annoyance

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -830,7 +830,7 @@ ylilauta.org##DIV[class^="center"]
 satakunnankansa.fi,valkeakoskensanomat.fi,nokianuutiset.fi,janakkalansanomat.fi,kmvlehti.fi,jamsanseutu.fi,suurkeuruu.fi,kankaanpaanseutu.fi,rannikkoseutu.fi,tyrvaansanomat.fi,merikarvialehti.fi,sydansatakunta.fi##.parade-ad.ad
 www.is.fi##div.sadblob-loading
 lbaanijakuva.fi##.background-ad:style(min-height: 0 !important;)
-www.finder.fi##.Advertisement__Box.Profile__Advertisement
+www.finder.fi##.Advertisement__Box
 
 ! Alypaa.com unbreak and block ads in a better way
 @@||sestatic.net^$image,domain=alypaa.com

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -679,8 +679,8 @@ krasivoe-kino.com$third-party
 verkkokauppa.com/api/richrelevance/customer
 ||seiska.fi*/js/ads.js$important
 ||seksitreffit.*popunder.js
-||seksitreffit.*/banners/$image
-||hippos.fi/banner/$image
+||seksitreffit.*/banners/
+||hippos.fi/banner/
 ||hobbyhall.fi*/pikkubanneri_
 /fillaritori/javascript_nbenhadverts/
 ||fillaritori.com/kuvat/*.gif

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -685,10 +685,6 @@ verkkokauppa.com/api/richrelevance/customer
 ||hobbyhall.fi*/pikkubanneri_
 /fillaritori/javascript_nbenhadverts/
 ||fillaritori.com/kuvat/*.gif
-||is.fi/hs-promo/$subdocument
-||hs.fi/promo/$subdocument
-||is.fi/is-promo/$subdocument
-||soppa365.fi$third-party
 ||snoobi.fi
 ||rakentaja.fi/kuvat/pi.gif
 ||omataloyhtio.fi/kuvat/pi.gif

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -17,7 +17,7 @@
 /markkinoinnin_nostot/*
 /cgi-sys/Count.cgi
 /bannerCounter.php
-
+/daxda-collector/
 /karuselli/js/AgAdCarousel
 /mainokset.
 /mainokset/*
@@ -34,6 +34,7 @@
 /mainoskaruselli.
 /mainoskaruselli/*
 /mainoskaruselli_yli
+/mainosmokkula/
 /pagestat?
 /sivulaskuri
 smartbanner
@@ -141,6 +142,7 @@ tyda.se#@#DIV[class*="advert"]
 ##div[class="ad-banner"]
 ##div.ALMACR-container
 ##div[class="block-ad"]
+##[href^="/artikkeli/kaupallinen-yhteistyo/"]
 
 ! -----GENERAL END-----
 ! -----EXTENDED FILTERS-----
@@ -524,6 +526,16 @@ wpengine.netdna-ssl.com/*/moottori/*/popup*.js
 horizonsunlimited.com##a[href*="9mmff.com"]
 seiska.fi##.tilaa-banner
 seiska.fi##.ad-inhouse-desktop
+alastonsuomi.com##.jb
+finnkino.fi##.advertising
+jatkoaika.com##div[class="block block-block"]
+high.fi###googlejs
+motot.net##div.centered.motot-well-inverse.well[style^="padding-"]
+basso.fi##div[id^="BannerBlock"]
+basso.fi##.ad-paraati
+nettikone.com###homeTopBoxBanner
+ticketmaster.fi##div[id^="ad-slot-"]
+tori.fi###delivery_methods .gray-text
 
 ! -----EXTENDED FILTERS END-----
 ! -----NETWORK FILTERS-----
@@ -667,6 +679,21 @@ eramebel.com$third-party
 krasivoe-kino.com$third-party
 verkkokauppa.com/api/richrelevance/customer
 ||seiska.fi*/js/ads.js$important
+||seksitreffit.*popunder.js
+||seksitreffit.*/banners/$image
+||hippos.fi/banner/$image
+||hobbyhall.fi*/pikkubanneri_
+/fillaritori/javascript_nbenhadverts/
+||fillaritori.com/kuvat/*.gif
+||is.fi/hs-promo/$subdocument
+||hs.fi/promo/$subdocument
+||is.fi/is-promo/$subdocument
+||soppa365.fi$third-party
+||snoobi.fi
+||rakentaja.fi/kuvat/pi.gif
+||omataloyhtio.fi/kuvat/pi.gif
+||omataloyhtio.fi/ffsw-pushcrew.js
+||lehtodigital.fi*/tracking.json
 
 ! -----NETWORK FILTERS END-----
 ! -----UNSORTED-----

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -227,7 +227,6 @@ feissarimokat.com##DIV[class="adbox-smaller"]
 feissarimokat.com##DIV[class="adbox-large"]
 feissarimokat.com##DIV[class="adbox-smaller nextpal"]
 feissarimokat.com##LI[class*="shopster"]
-fillaritori.com##.ipsAdvertisement
 gamereactor.fi##div[id="eventad"]
 hardware.fi##DIV[class="top-ad-space"]
 hbl.fi##ksf-adblockers

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -693,6 +693,7 @@ verkkokauppa.com/api/richrelevance/customer
 ||rakentaja.fi/kuvat/pi.gif
 ||omataloyhtio.fi/kuvat/pi.gif
 ||omataloyhtio.fi/ffsw-pushcrew.js
+||puutarha.net/ffsw-pushcrew.js
 ||lehtodigital.fi*/tracking.json
 
 ! -----NETWORK FILTERS END-----

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -63,3 +63,6 @@ www.hs.fi##.embedded:has-text(Markkinapaikka)
 
 ! iltalehti.fi - ad container
 www.iltalehti.fi##div.card:has-text(Mainos: )
+
+basso.fi###header:style(min-height: auto !important)
+basso.fi###header-main:style(margin-top: 0px !important)

--- a/annoyances/Finland_annoyances.txt
+++ b/annoyances/Finland_annoyances.txt
@@ -70,7 +70,7 @@ www.is.fi##[id^="DefaultShareButtons-"]
 www.is.fi##[id^="ShareButtons-"]
 www.aamulehti.fi##[href^="mailto:"] > .fa-envelope.fa
 bbs.io-tech.fi##[href="https://www.facebook.com/iotechfi/"]
-
+puutarha.net,omataloyhtio.fi,rakentaja.fi###scrak_CONT_keski
 yle.fi##footer > .default.some
 yle.fi##div.ydd-share-buttons
 yle.fi##.hgroup > .default.some
@@ -83,6 +83,8 @@ rekrytointi.com##.essb_mailform
 hintaseuranta.fi###some-buttons
 mobiili.fi##.likes-top
 ||mobiili.fi/images/some_icons/$image
+mikroaitta.fi###facebook_block
+jatkoaika.com##.somelinks
 
 ! NEWSLETTERS
 iltalehti.fi###newsletter_container
@@ -92,6 +94,11 @@ www.ess.fi###uutiskirjeentilaus
 www.hs.fi##.hsnl-container
 seiska.fi##.newsletter
 mobiili.fi##.mobuutiskirje_link
+netrauta.fi##.email-collector
+verkkokauppa.com##.footer__catalog-newsletter-container
+verkkokauppa.com##.promo-item-container
+omataloyhtio.fi##.scrakentajafi_share_uutiskirje
+hobbyhall.fi##.newsletter
 
 ! DOWNLOAD OUR APP
 iltalehti.fi##[href="/sovellus"]
@@ -120,3 +127,7 @@ is.fi/kampanjat/vinkkinapit
 www.iltalehti.fi##.block:has([href="/uutisvihje"])
 www.is.fi##iframe[data-original*="is.fi/kampanjat/vinkkinapit"]
 seiska.fi##.klubi-banner
+||osterbottenstidning.fi/Scripts/StickyNotification
+lehtodigital.fi###_kmg_cookie_accept
+||varmalaina.fi/wp-content/plugins/yeloni-free-exit-popup/
+||knaitek.fi/magebirdpopup.php

--- a/annoyances/Finland_annoyances.txt
+++ b/annoyances/Finland_annoyances.txt
@@ -18,7 +18,7 @@
 
 ! RANDOM
 
-||nelonenmedia.fi/xb/styles/logo/public/is_trans_35x35px.png
+||nelonenmedia.fi/xb/styles/logo/public/
 
 huuto.net###display-window-container
 huuto.net###oikotie-nav
@@ -51,6 +51,9 @@ www.aamulehti.fi###iltalehtiBox-2
 www.hs.fi##iframe[data-original="https://vg.is.fi/is-promo/"]
 
 ||is.fi/is-promo/$subdocument,third-party
+||is.fi/hs-promo/$subdocument
+||hs.fi/promo/$subdocument
+||soppa365.fi$third-party
 ||uutisboksi.il.fi/$subdocument,third-party
 
 ! Iltapulu

--- a/annoyances/Finland_annoyances_uBO_extras.txt
+++ b/annoyances/Finland_annoyances_uBO_extras.txt
@@ -30,5 +30,5 @@ www.iltalehti.fi##.jw-reset-text.jw-related-title
 www.iltalehti.fi##.jw-overlay.jw-related.jw-reset
 www.iltalehti.fi##.jw-related-shelf-container
 
-omataloyhtio.fi##+js(setTimeout-defuser.js,,1)
+omataloyhtio.fi,puutarha.net##+js(setTimeout-defuser.js,,1)
 maanmittauslaitos.fi##.dialog-off-canvas-main-canvas:style(padding-top: 0px !important)

--- a/annoyances/Finland_annoyances_uBO_extras.txt
+++ b/annoyances/Finland_annoyances_uBO_extras.txt
@@ -29,3 +29,6 @@ www.iltalehti.fi##.jw-related-container.jw-reset
 www.iltalehti.fi##.jw-reset-text.jw-related-title
 www.iltalehti.fi##.jw-overlay.jw-related.jw-reset
 www.iltalehti.fi##.jw-related-shelf-container
+
+omataloyhtio.fi##+js(setTimeout-defuser.js,,1)
+maanmittauslaitos.fi##.dialog-off-canvas-main-canvas:style(padding-top: 0px !important)

--- a/annoyances/Finland_annoyances_uBO_extras.txt
+++ b/annoyances/Finland_annoyances_uBO_extras.txt
@@ -32,3 +32,6 @@ www.iltalehti.fi##.jw-related-shelf-container
 
 omataloyhtio.fi,puutarha.net##+js(setTimeout-defuser.js,,1)
 maanmittauslaitos.fi##.dialog-off-canvas-main-canvas:style(padding-top: 0px !important)
+
+lehtodigital.fi##.fade
+lehtodigital.fi##html:style(overflow-y: auto !important)


### PR DESCRIPTION
/daxda-collector/ is at http://www.yritystele.fi/yrityksen-tiedot/auruaudio-oy/yhteystiedot/692436
hs.fi/promo/ is at https://www.sanakirja.org/
is.fi/hs-promo/ is at https://hintaseuranta.fi/puhelimet/samsung-galaxy-s8-puhelin/5705850
/mainosmokkula/ is at https://www.seksitreffit.com/forum/
##[href^="/artikkeli/kaupallinen-yhteistyo/"] is at tiede.fi,etlehti.fi
soppa365.fi frame is at tiede.fi
||nelonenmedia.fi/xb/styles/logo/public/ shortened so it works on hs.fi also as well as is.fi
all of the lehtodigital.fi rules are for https://lehtodigital.fi/lmath/
