### PR TITLE
www.power.fi - order tracking

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -892,6 +892,7 @@ io-tech.fi#@#.sidebar-widgets
 @@||turku.fi/sites/default/files/styles/current/public/images/
 etuovi.com#@#.rss-feed
 tjareborg.fi#@#.push-container
+@@||www.power.fi/Umbraco/Api/Tracking/TrackOrder$xmlhttprequest,domain=www.power.fi
 
 
 ! Fanboy's Annoyance List


### PR DESCRIPTION
Easyprivacy breaks order tracking on `www.power.fi` - made a fix for it.

`https://www.power.fi/tuki/tilausten-seuranta/`