### PR TITLE
pt-media.org - empty ad boxes that are left after adblocking

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -407,6 +407,10 @@ petri.com##DIV#simplemodal-container[class="simplemodal-container"]
 petri.com##DIV#simplemodal-overlay[class="simplemodal-overlay"]
 pohjalainen.fi##div[class="ads__wrapper--pinnedtop"]
 pohjalainen.fi##div[class*="pohjanmaan-palvelut__wrapper"]
+pt-media.org##.wpcnt-header.wpcnt
+pt-media.org##.theiaStickySidebar > .wpcnt
+pt-media.org###main > .wpcnt > .wpa
+pt-media.org##.entry-content > .wpcnt
 radiopori.fi##div[class*="simpleads"]
 radiopori.fi##div[id*="mainospaikka"]
 pku.fi##ASIDE[class*="adrotate"]


### PR DESCRIPTION
`https://pt-media.org/`