### PR TITLE
To block empty mobile ad boxes on hs.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -236,6 +236,7 @@ hbl.fi##ksf-adblockers
 hastens.com##div[class="footer-cookies"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[class*="lyads"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[id="ensNotifyBanner"][class="ensNotifyBanner"]
+hs.fi##.aldente-wrapper
 hs.fi##DIV[class*="ad-container"]
 hs.fi##DIV[class*="-ad-block"]
 hs.fi##DIV#story-package-container[class="story-package"]


### PR DESCRIPTION
Some screenshots:

![photo_2019-04-28_16-21-39](https://user-images.githubusercontent.com/17256841/56865019-d9858b80-69d1-11e9-87e2-553bb7af3460.jpg)

![photo_2019-04-28_16-21-28](https://user-images.githubusercontent.com/17256841/56865021-e3a78a00-69d1-11e9-833a-12a610966fb3.jpg)

![photo_2019-04-28_15-33-14](https://user-images.githubusercontent.com/17256841/56865022-e5714d80-69d1-11e9-90d9-8e9f5cc7f848.jpg)

![photo_2019-04-28_16-21-44](https://user-images.githubusercontent.com/17256841/56865023-e6a27a80-69d1-11e9-8f2c-19a8001cfdde.jpg)
