### PR TITLE
more empty mobile ad boxes on hs.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -236,6 +236,9 @@ hbl.fi##ksf-adblockers
 hastens.com##div[class="footer-cookies"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[class*="lyads"]
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[id="ensNotifyBanner"][class="ensNotifyBanner"]
+hs.fi###aldente-mobibanner01_0
+hs.fi###aldente-mobibanner02_0
+hs.fi###aldente-mobicontentfeedhigh_0
 hs.fi##.aldente-wrapper
 hs.fi##DIV[class*="ad-container"]
 hs.fi##DIV[class*="-ad-block"]


### PR DESCRIPTION
I guess they have "backup" rules... Here is one screenshot:

![photo_2019-05-07_15-23-41](https://user-images.githubusercontent.com/17256841/57299015-425cba00-70dc-11e9-9266-776042f08e65.jpg)


