### PR TITLE
Supla ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -792,6 +792,7 @@ www.vr.fi##.headerContents > .infoMessages
 ||nelonenmedia.fi/ads/$media
 ||nelonenmedia-pmd-ads-manual.nm-stream.nelonenmedia.fi/$media
 ||nelonenmedia-pmd-ads-spotgate.nm-stream.nelonenmedia.fi/$media
+||nelonenmedia-pmd-ads-audio.nm-stream.nelonenmedia.fi/$media
 
 ! unbreak "Suosituimmat" ("most popular") on mtvuutiset.fi
 @@leiki.com/mtv3/widgets/loader/$domain=mtvuutiset.fi


### PR DESCRIPTION
This rule blocks ads on supla-podcasts. On this article `https://www.hs.fi/politiikka/art-2000006113986.html` is a supla podcast that had ad before the podcast started.