### PR TITLE
Suggestion to remove utag/sanoma

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -64,7 +64,6 @@ nelonenmedia.fi/hitcounter
 /js/common/spring
 /js/common/init-tns
 /eu_cookie_compliance.js
-/utag/sanoma-fi/
 /finnair-analytics/
 
 ###atwAdFrame
@@ -771,7 +770,6 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 mobiili.fi#@#.header_ad
 @@||adservicemedia.dk/$image,domain=mobiili.fi
 www.rauhanpuolustajat.org#@#div[data-nconvert-cookie]
-@@||tags.tiqcdn.com/utag/sanoma-fi/lifestyle/prod/utag.js$script,domain=www.meidanperhe.fi
 
 ! Unbreak radiot.fi
 @@||analytics-sdk.yle.fi/yle-analytics.min.js$script,domain=radiot.fi|tunnus.yle.fi
@@ -929,7 +927,6 @@ io-tech.fi#@#.sidebar-widgets
 @@||turku.fi/sites/default/files/styles/current/public/images/
 etuovi.com#@#.rss-feed
 tjareborg.fi#@#.push-container
-@@||tags.tiqcdn.com/utag/sanoma-fi/lifestyle/prod/utag.js$script,domain=www.vauva.fi
 @@||www.power.fi/Umbraco/Api/Tracking/TrackOrder$xmlhttprequest,domain=www.power.fi
 @@||uk.cdn-net.com/cc.js$script,domain=www.power.fi
 


### PR DESCRIPTION
This filter has caused issues on Sanoma Oyj owned sites (vauva.fi #85 meidanperhe.fi #109 ). I think it's highly likely that it might cause issues we are not aware of on other Sanoma Oyj owned sites also. I don't think it's very future proof either. Filter is too general.