### PR TITLE
Added filter for empty ad container on mtvuutiset and sorted lines

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -384,6 +384,12 @@ mtv.fi##IFRAME#hz-unit-etusivu
 mtv.fi/static/javascripts/external-js/*.js
 mtv.fi##div[class="leaderboard"]
 mtv.fi##DIV[class*="ad-container"]
+mtvuutiset.fi###leaderboard-2
+mtvuutiset.fi##.ad_fadein
+mtvuutiset.fi##.component-adincontent.component
+mtvuutiset.fi##.leaderboard-1.leaderboard
+mtvuutiset.fi##.leaderboard-2.leaderboard.ad-container
+mtvuutiset.fi##div.ad-container.component
 mvlehti.net##.ad
 mvlehti.net##.entry-content > .premium_container
 mvlehti.net##.comments-container > .premium_container
@@ -804,13 +810,6 @@ www.vr.fi##.headerContents > .infoMessages
 ! unbreak "Suosituimmat" ("most popular") on mtvuutiset.fi
 @@leiki.com/mtv3/widgets/loader/$domain=mtvuutiset.fi
 @@leiki.com/mtv3/mwidget$domain=mtvuutiset.fi
-
-! hide ad containers on mtvuutiset.fi
-mtvuutiset.fi##div.ad-container.component
-mtvuutiset.fi###leaderboard-2
-mtvuutiset.fi##.component-adincontent.component
-mtvuutiset.fi##.leaderboard-1.leaderboard
-mtvuutiset.fi##.ad_fadein
 
 ! Media unbreakers
 @@||fwmrm.net/ad/$script,domain=dplay.fi


### PR DESCRIPTION
I added this filter: `mtvuutiset.fi##.leaderboard-2.leaderboard.ad-container` and also sorted other mtvuutiset filters in alphabetical order and moved them right after mtv.fi since there is no need for a separate section.

Screenshots of an empty container:

![photo_2019-05-30_18-20-30](https://user-images.githubusercontent.com/17256841/58643389-d7cc2200-8307-11e9-826b-d47d628cbba9.jpg)

![photo_2019-05-30_18-20-34](https://user-images.githubusercontent.com/17256841/58643401-dbf83f80-8307-11e9-895e-1cd69a27510e.jpg)

(Images are a bit yellowish because of night filter that filters bluelight)