### PR TITLE
Viafree adblocking doesn't work anymore, here is fix

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -822,11 +822,11 @@ mtvuutiset.fi,mtv.fi,suomiareena.fi,www.studio55.fi,lumijapyry.fi,www.msn.com##.
 ||cloudfront.net/creatives/assets/$image,domain=mtvuutiset.fi
 
 ! To make viafree.fi videos to work without ads
+@@||fwmrm.net/ad/*$xmlhttprequest,domain=www.viafree.fi
+@@||fwmrm.net/crossdomain.xml$xmlhttprequest,domain=www.viafree.fi
 @@||mssl.fwmrm.net/p/MTG_Brightcove_HTML5/AdManager.js$script,domain=www.viafree.fi
-@@||fwmrm.net/ad/$xmlhttprequest,domain=www.viafree.fi
-@@||playapi.mtgx.tv/$xmlhttprequest,domain=www.viafree.fi
-@@||fwmrm.net/ad/$script,domain=www.viafree.fi
-||freewheel-mtgx-tv.akamaized.net/$media,domain=www.viafree.fi
+@@||fwmrm.net/ad/*$script,domain=www.viafree.fi
+||freewheel-mtgx-tv.akamaized.net/m/1/*.mp4$media,domain=www.viafree.fi
 
 ! block "sponsored articles"/"native ads" on some sites
 ##.spklw-post-attr[data-type="ad"]

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -823,9 +823,10 @@ mtvuutiset.fi,mtv.fi,suomiareena.fi,www.studio55.fi,lumijapyry.fi,www.msn.com##.
 
 ! To make viafree.fi videos to work without ads
 @@||fwmrm.net/ad/*$xmlhttprequest,domain=www.viafree.fi
+@@||fwmrm.net/ad/*$script,domain=www.viafree.fi
+@@||fwmrm.net/ad/*$image,domain=www.viafree.fi
 @@||fwmrm.net/crossdomain.xml$xmlhttprequest,domain=www.viafree.fi
 @@||mssl.fwmrm.net/p/MTG_Brightcove_HTML5/AdManager.js$script,domain=www.viafree.fi
-@@||fwmrm.net/ad/*$script,domain=www.viafree.fi
 ||freewheel-mtgx-tv.akamaized.net/m/1/*.mp4$media,domain=www.viafree.fi
 
 ! block "sponsored articles"/"native ads" on some sites


### PR DESCRIPTION
Here is a sample link to test with: `https://www.viafree.fi/ohjelmat/dokumentit/the-olympian/kausi-1/jakso-5` (note: sometimes they stop showing ads for a specific video if already shown, so changing test videos is needed).

Also had to remove entries from Ubo extras file: #117 