### PR TITLE
Mtv videos don't work anymore, fix made

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -820,6 +820,7 @@ www.vr.fi##.headerContents > .infoMessages
 mtvuutiset.fi,mtv.fi,suomiareena.fi,www.studio55.fi,lumijapyry.fi,www.msn.com##.mtv-player-ad-container
 ||damoh.katsomo.fi/*$image,domain=mtvuutiset.fi|mtv.fi|suomiareena.fi|www.studio55.fi|lumijapyry.fi|www.msn.com
 ||cloudfront.net/creatives/assets/$image,domain=mtvuutiset.fi
+@@||fi-mtv3.videoplaza.tv/proxy/pulse-sdk-html5/*/latest.min.js$script
 
 ! To make viafree.fi videos to work without ads
 @@||mssl.fwmrm.net/p/MTG_Brightcove_HTML5/AdManager.js$script,domain=www.viafree.fi


### PR DESCRIPTION
Easylist has started to break MTV videos. I made a whitelist rule to unbreak it. Sample link to test with: `https://www.mtvuutiset.fi/artikkeli/mtv-n-kysely-joka-toinen-suomalainen-siirtaisi-kauppojen-rahapeliautomaatit-valvottuihin-tiloihin-kauppareissulla-voi-mattaa-rahaa-peleihin-eika-se-pysy-kaikilla-hallinnassa/7518262`