### PR TITLE
studio55 empty ad container remnants

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -447,6 +447,7 @@ sfnix.net/api/
 ! snstatic.fi/webstatic/*/desktop-all.js
 stream.almamedia.fi/mp/salsabanner
 meta.almamedia.io/v1/text?
+studio55.fi##.ad-container.banner
 suomensanomat.fi##div[class="static-info"]
 suomela.fi##div[class*="simplemodal"]
 suomela.fi##div[class*="banner"]


### PR DESCRIPTION
Can be found on the articles. Sample link: `https://www.studio55.fi/hyvinvointi/article/20-todistetta-etta-sinulla-menee-paremmin-kuin-luulet/6328798`