### PR TITLE
p.typekit.net is a font provider

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -650,7 +650,6 @@ spring-tns.net$third-party
 ||nr-data.net$third-party
 ||nugg.ad^
 ||outbrain.com$third-party
-||p.typekit.net^
 ||parkingcrew.net^
 ||partner.shareaholic.com^
 ! perfectmarket.com redirects to taboola.com.


### PR DESCRIPTION
p.typekit.net is service that provices Adobe Font's fontpacks. How this got here? Or is it used for something else as well?