### PR TITLE
Iltalehti - anti-adblock

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -280,7 +280,6 @@ hinta.fi##div[class="hv-wrapper-right-item"]
 hinta.fi##div[class="hv-wrapper-left-item"]
 ilkka.fi/logger
 iltalehti.fi##div[class*="parade-ad-container"]
-iltalehti.fi##.jw-reset.jw-video
 iltalehti.fi##.slider-content
 iltalehti.fi##div[class="iframe-container"]
 @@||leiki.com$domain=iltalehti.fi
@@ -778,6 +777,7 @@ kaleva.fi##DIV[id="kaleva-cookie-consent"]
 mobiili.fi#@#.header_ad
 @@||adservicemedia.dk/$image,domain=mobiili.fi
 www.rauhanpuolustajat.org#@#div[data-nconvert-cookie]
+iltalehti.fi#@#.afs_ads
 
 ! https://bbs.io-tech.fi/threads/keskustelua-selainten-mainos-ja-yksityisyysestoista.692/page-10#post-3842308
 ! hintaseuranta elementit

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -280,6 +280,7 @@ hinta.fi##div[class="hv-wrapper-right-item"]
 hinta.fi##div[class="hv-wrapper-left-item"]
 ilkka.fi/logger
 iltalehti.fi##div[class*="parade-ad-container"]
+iltalehti.fi##.jw-reset.jw-video
 iltalehti.fi##.slider-content
 iltalehti.fi##div[class="iframe-container"]
 @@||leiki.com$domain=iltalehti.fi


### PR DESCRIPTION
`https://www.iltalehti.fi/iltv-paivarinta/a/a7f90aa1-d0cd-4704-a7bb-5c20622657f4`

Made a fixing rule. Note: Sometimes that video works and sometimes that text comes up even without doing any rules. But after applying this rule it works all the time. No ads appeared. Easylist broke this.

(I first made a non-working rule but now it's proper.)

Screenshot:

![Screenshot_2019-09-04 Sensuroimaton Päivärinta, jakso 70 Tunteet kuumenivat, katso Husu Husseinin ja Riikka Purran kohtaami](https://user-images.githubusercontent.com/17256841/64274377-f0258b80-cf4b-11e9-8646-8ce72a871a24.jpg)
