### PR TITLE
mvlehti - brave browser ad

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -392,6 +392,7 @@ mtvuutiset.fi##div.ad-container.component
 mvlehti.net##.ad
 mvlehti.net##.entry-content > .premium_container
 mvlehti.net##.comments-container > .premium_container
+||static.mvlehti.net/uploads/2018/03/brave-3*.jpg$image
 www.nettiauto.com,www.nettimoto.com,www.nettivaraosa.com,www.nettimarkkina.com,www.nettikone.com##LI#left_part
 www.nettiauto.com,www.nettimoto.com,www.nettivaraosa.com,www.nettimarkkina.com,www.nettikone.com##DIV[id="huge_banner"]
 www.nettiauto.com,www.nettimoto.com,www.nettivaraosa.com,www.nettimarkkina.com,www.nettikone.com##DIV[class*="emediate_ad"]


### PR DESCRIPTION
Sample link: `https://mvlehti.net/2018/03/25/valetoimittaja-kreeta-karvala-kutsuu-mv-mediaa-vihasivustoksi/`