### PR TITLE
removed couple obsolete rules

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -262,7 +262,6 @@ hifimaailma.fi##div[id="secondary"]
 hifimaailma.fi##div[class="kake"]
 hinta.fi##a[href^="/ohjaus.php"]
 huoltovalikko.com##A[href="http://www.satshop.fi"]
-elisaviihde.fi##SECTION#cookie-warning[class="cookie-notification warning"]
 elisa.fi/img/content/*.mp4
 f1-forum.fi##img[src*="banneri"]
 f1-forum.fi##a[href*="netb11.com"]
@@ -877,7 +876,6 @@ www.finder.fi##.Advertisement__Box
 
 ! Alypaa.com unbreak and block ads in a better way
 @@||sestatic.net^$image,domain=alypaa.com
-||nelonenmedia.fi$domain=alypaa.com
 
 ! links to ad servers
 ##[href^="https://clk.tradedoubler.com/click"]


### PR DESCRIPTION
`elisaviihde.fi##SECTION#cookie-warning[class="cookie-notification warning"]` - a non-working rule. And besides, Fanboy's cookie list blocks it correctly.

`||nelonenmedia.fi$domain=alypaa.com` - not necessary as älypää is part of Sanoma Oyj which ads are blocked by other rules