### PR TITLE
keskustelu.suomi24.fi - ad on the upper right side of the page

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -313,6 +313,7 @@ kukasoitti.com##a[href*='adsrv']
 kukasoitti.com##DIV[class="main-bottom"]
 monster.almamedia.fi/nostobannerit/
 kelkkalehti.com/bannerit/
+keskustelu.suomi24.fi##div.center-block.no-padding.lt-res-below-2.ad-fluid.ad-container.ad.keskustelu-column3-ad
 kuljetusnet.fi##div[id*="banner"]
 kuljetusnet.fi##div[class*="banner"]
 kuopionkirppari.fi##DIV[class*="banner"]


### PR DESCRIPTION
`https://keskustelu.suomi24.fi/` (at the moment that ad is providing links to `seiska.fi`)