### PR TITLE
seiska.fi ad container remnants on articles

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -443,6 +443,7 @@ satakunnankansa.fi##DIV[class="s-ryhma-carousel-wrapper"]
 satakunnankansa.fi##DIV[class^="adContainer"]
 savonsanomat.fi##DIV[class="uutiskirje"]
 savonsanomat.fi##DIV[class*="customAd"]
+seiska.fi##div.article-ad-container
 sfnix.net/api/
 ! snstatic.fi/webstatic/*/desktop-all.js
 stream.almamedia.fi/mp/salsabanner


### PR DESCRIPTION
Sample link: `https://www.seiska.fi/Uutiset/Kuin-isku-palleaan-Porvoon-poliisiampumisista-epailtyjen-veljesten-isa-poikiensa-teon`