### PR TITLE
Aamulehti - bottom ad

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -161,11 +161,12 @@ aamulehti.fi##div[class="sidebar frontpageBottom"]
 aamulehti.fi##div[class="mainColRight is_stuck"]>div>div>iframe
 aamulehti.fi/*/spring.js
 aamulehti.fi/*/alma_init_cjs.js
+aamulehti.fi###bottomBanner
 aamulehti.fi##.huCagr.sc-fFTYTi
 aamulehti.fi##.fKjNmg.sc-kDhYZr
 aamulehti.fi##.parade-ad.ad
-www.aamulehti.fi###promo-1
-www.aamulehti.fi###promo-2
+aamulehti.fi###promo-1
+aamulehti.fi###promo-2
 aamuset.fi##DIV#block-views-etusivukaruselli-block
 aamuset.fi##DIV#block-views-mainoskaruselli-block
 aamuset.fi##DIV[class="adslist"]


### PR DESCRIPTION
`https://www.aamulehti.fi/` they advertise to subscribe for their magazine on a bottom ad which is very annoying as it takes space from screen.