### PR TITLE
kansanuutiset.fi ad container remnant in the middle of an article

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -298,6 +298,7 @@ ibtimes.co.uk##IFRAME[id="newsletter_popup"]
 iro.fi/Surveys/
 kansalainen.fi##div[id^="ads"]
 kansalainen.fi##div[id="text-html-widget-5"]
+kansanuutiset.fi##.intextad.clearfix.cb-module-block.cb-box.cb-a-large
 kansanuutiset.fi##A[href="http://www.autonvaraosastore.fi/"]
 kansanuutiset.fi##div[class*="intextad"]
 karjalainen.fi##center


### PR DESCRIPTION
Sample link: `https://www.kansanuutiset.fi/artikkeli/4135174-boris-johnsonin-uskomaton-kahden-kirjeen-brexit-taktiikka`