### PR TITLE
Kaupallinen yhteistyö (ad articles) on iltalehti.fi and ad podcasts talouselama.fi

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -42,6 +42,7 @@ www.iltalehti.fi##[href^="/thaimaaextra"]:has([src*="assets.ilcdn.fi/Nauha_Ranta
 www.iltalehti.fi##[href^="/unikulma/"]:has-text(Kaupallinen yhteistyö)
 www.iltalehti.fi##.block > .article-list-api-wrapper > .article-list > div > a > .article-container:has-text(Kaupallinen yhteistyö )
 www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/mainosnauha"])
+www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat/nauhat/mainosnauha"])
 
 ! suomi.fi kaupallinen yhteistyö
 www.iltalehti.fi##.drfront-full-article:has([src="https://assets.ilcdn.fi/f6d9bb889ba0d9fde55f3e67169fcbb61802a5597e5eb7e0765d262c6733dda6.jpg"])

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -47,6 +47,9 @@ www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat
 ! suomi.fi kaupallinen yhteistyö
 www.iltalehti.fi##.drfront-full-article:has([src="https://assets.ilcdn.fi/f6d9bb889ba0d9fde55f3e67169fcbb61802a5597e5eb7e0765d262c6733dda6.jpg"])
 
+! talouselama.fi kaupallinen yhteistyö
+www.talouselama.fi##div#skyscraper-height-div > div > aside > div > div:has-text(KAUPALLINEN YHTEISTYÖ)
+
 ! Tori.fi
 www.tori.fi##.item_row.ds-box:has(img[src*="cloudfront.net/img/veikkaus"])
 www.tori.fi##.item_row.ds-box:has(img[src*="cloudfront.net/img/vepsalainen"])

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -41,6 +41,7 @@ www.iltalehti.fi##.drfront-full-article:has-text(Kaupallinen yhteistyö Urakkama
 www.iltalehti.fi##[href^="/thaimaaextra"]:has([src*="assets.ilcdn.fi/Nauha_Rantapallo_"])
 www.iltalehti.fi##[href^="/unikulma/"]:has-text(Kaupallinen yhteistyö)
 www.iltalehti.fi##.block > .article-list-api-wrapper > .article-list > div > a > .article-container:has-text(Kaupallinen yhteistyö )
+www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/mainosnauha"])
 
 ! suomi.fi kaupallinen yhteistyö
 www.iltalehti.fi##.drfront-full-article:has([src="https://assets.ilcdn.fi/f6d9bb889ba0d9fde55f3e67169fcbb61802a5597e5eb7e0765d262c6733dda6.jpg"])

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -30,7 +30,6 @@ www.iltalehti.fi##[href^="/omaguru/"]:has(.article-container:has-text(Kaupalline
 www.iltalehti.fi##[href^="/hintaopas/"]:has(.article-container:has-text(Kaupallinen yhteistyö Hintaopas: ))
 www.iltalehti.fi##.default.drfront-full-article:has([href^="/hintaopas/"]):has(img[src*="assets.ilcdn.fi/mainosnauhta_digi_hintaopas.jpg"])
 www.iltalehti.fi##div.article-container:has-text(Kaupallinen yhteistyö: ):has([href^="/omaguru/"])
-
 www.iltalehti.fi##[href^="/rahoitufi/"]:has(.article-image-content):has([src*="static.ilcdn.fi/kuvat/nauhat/mainosnauha-asuminen-rahoitufi.jpg"])
 www.iltalehti.fi##[href^="/asumisartikkelit/"]:has(.article-banner):has([src*="assets.ilcdn.fi/asuminen_vattenfall_palkki.jpg"])
 www.iltalehti.fi##[href^="/kodin-turvallisuus/"]:has(img[src*="assets.ilcdn.fi/mainosnauha-asuminen-verisure.jpg"])
@@ -43,6 +42,11 @@ www.iltalehti.fi##[href^="/unikulma/"]:has-text(Kaupallinen yhteistyö)
 www.iltalehti.fi##.block > .article-list-api-wrapper > .article-list > div > a > .article-container:has-text(Kaupallinen yhteistyö )
 www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/mainosnauha"])
 www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat/nauhat/mainosnauha"])
+www.iltalehti.fi##.mc-full-article:has-text(Kaupallinen yhteistyö)
+www.iltalehti.fi##div.mc-half-article:has-text(Kaupallinen yhteistyö)
+www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/terveys_palkki_vitaelab_kaupallinenyht.jpg"])
+www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat/nauhat/ky_asuminen_unikulma.jpg"])
+www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/kaupallinenyhteistyo"])
 
 ! suomi.fi kaupallinen yhteistyö
 www.iltalehti.fi##.drfront-full-article:has([src="https://assets.ilcdn.fi/f6d9bb889ba0d9fde55f3e67169fcbb61802a5597e5eb7e0765d262c6733dda6.jpg"])


### PR DESCRIPTION
These filters block commercial cooperation ad articles on these pages:

`https://www.iltalehti.fi/tyylicom`
`https://www.iltalehti.fi/terveys`
`https://www.iltalehti.fi/perhe`
`https://www.iltalehti.fi/asuminen`
`https://www.iltalehti.fi/pippuri`

and ad podcasts on this link: `https://www.talouselama.fi/`