### PR TITLE
tivi.fi - commercial cooperation stuff

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -56,6 +56,7 @@ www.tivi.fi##div#skyscraper-height-div > aside > a:has-text(Kaupallinen yhteisty
 www.tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > section > div:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > div > aside > a:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##div#skyscraper-height-div > div > section > div:has-text(Kaupallinen yhteistyö)
 
 ! Lapinkansa.fi - Commercial cooperation ("Kaupallinen yhteistyö") articles
 www.lapinkansa.fi##article.narrow.news-item:has(.topic-link-nat.topic-link:has-text(Kaupallinen yhteistyö))

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -52,6 +52,9 @@ www.tori.fi##.item_row.ds-box:has(img[src*="cloudfront.net/img/vepsalainen"])
 ! Tivi.fi - Kaupallinen yhteistyö
 www.tivi.fi##.teaser-partner-blog:has-text(KAUPALLINEN YHTEISTYÖ: )
 www.tivi.fi##.section-partner:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##div#skyscraper-height-div > aside > a:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##div#skyscraper-height-div > section > div:has-text(Kaupallinen yhteistyö)
 
 ! Lapinkansa.fi - Commercial cooperation ("Kaupallinen yhteistyö") articles
 www.lapinkansa.fi##article.narrow.news-item:has(.topic-link-nat.topic-link:has-text(Kaupallinen yhteistyö))

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -55,6 +55,7 @@ www.tivi.fi##.section-partner:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > aside > a:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > section > div:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##div#skyscraper-height-div > div > aside > a:has-text(Kaupallinen yhteistyö)
 
 ! Lapinkansa.fi - Commercial cooperation ("Kaupallinen yhteistyö") articles
 www.lapinkansa.fi##article.narrow.news-item:has(.topic-link-nat.topic-link:has-text(Kaupallinen yhteistyö))


### PR DESCRIPTION
Most of these rules block ad blogs and articles on the front page.

This rule however `www.tivi.fi##div#skyscraper-height-div > div > aside > a:has-text(Kaupallinen yhteistyö)` blocks ad blogs that are linked through subpages, example: `https://www.tivi.fi/uutiset/aika-vin-paha-aukko-loytynyt-lahes-kaikkia-puhelimia-voidaan-vakoilla/82e4084c-ad2d-40f5-92c3-12dbb997e44a`

And this rule `www.tivi.fi##div#skyscraper-height-div > div > section > div:has-text(Kaupallinen yhteistyö)` blocks ad articles inside subpages.