### PR TITLE
mediuutiset.fi - Commercial cooperation

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -58,6 +58,13 @@ www.lapinkansa.fi##article.narrow.news-item:has(.topic-link-nat.topic-link:has-t
 www.lapinkansa.fi##article.news-item.front-page-news-item.featured:has(.topic-link-nat.topic-link:has-text(Kaupallinen yhteistyö))
 www.lapinkansa.fi##div.small-news-item.content > .border-bottom.news-item.front-page-news-item:has(.topic-link-nat.topic-link:has-text(Kaupallinen yhteistyö))
 
+! mediuutiset.fi - Commercial cooperation
+www.mediuutiset.fi##div#skyscraper-height-div > div > aside > div > div:has-text(Kaupallinen yhteistyö)
+www.mediuutiset.fi##div#skyscraper-height-div > div > aside > div > a:has-text(Kaupallinen yhteistyö)
+www.mediuutiset.fi##div#skyscraper-height-div > div > section > a:has-text(Kaupallinen yhteistyö)
+www.mediuutiset.fi##div#skyscraper-height-div > div > div:has-text(Kaupallinen Yhteistyö)
+www.mediuutiset.fi##div#root > div > div > div > div > div > div:has-text(Kaupallinen Yhteistyö)
+
 ! hs.fi - "Markkinapaikka" ad container
 www.hs.fi##.embedded:has-text(Markkinapaikka)
 


### PR DESCRIPTION
Most rules block co-stuff on the front page.

This rule `www.mediuutiset.fi##div#root > div > div > div > div > div > div:has-text(Kaupallinen Yhteistyö)` blocks co stuff on the subpage, sample page: `https://www.mediuutiset.fi/uutiset/avohoito-laajenee-erikoissairaanhoidossa-avohoidossa-on-jo-kaksi-miljoonaa-potilasta/4eacd73e-4639-4ee2-acf4-38a9dfbc4fc1` (almost at the end of the page, article container)