### PR TITLE
Co stuff on kauppalehti.fi

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -42,6 +42,12 @@ www.iltalehti.fi##[href^="/thaimaaextra"]:has([src*="assets.ilcdn.fi/Nauha_Ranta
 www.iltalehti.fi##[href^="/unikulma/"]:has-text(Kaupallinen yhteistyö)
 www.iltalehti.fi##.block > .article-list-api-wrapper > .article-list > div > a > .article-container:has-text(Kaupallinen yhteistyö )
 
+! kauppalehti.fi - Commercial cooperation
+www.kauppalehti.fi##div#skyscraper-height-div > aside > aside > section > a:has-text(Kaupallinen yhteistyö)
+www.kauppalehti.fi##div#skyscraper-height-div > main > aside > div > a:has-text(Kaupallinen yhteistyö)
+www.kauppalehti.fi##div#skyscraper-height-div > div > aside > aside > section > a:has-text(Kaupallinen yhteistyö)
+www.kauppalehti.fi##div#skyscraper-height-div > div > main > a:has-text(Kaupallinen yhteistyö)
+
 ! suomi.fi kaupallinen yhteistyö
 www.iltalehti.fi##.drfront-full-article:has([src="https://assets.ilcdn.fi/f6d9bb889ba0d9fde55f3e67169fcbb61802a5597e5eb7e0765d262c6733dda6.jpg"])
 


### PR DESCRIPTION
Blocked stuff on these links:

`https://www.kauppalehti.fi/fakta`
`https://www.kauppalehti.fi/optio`
`https://www.kauppalehti.fi/`