### PR TITLE
Problematic rule for tivi.fi - causes problems + new rules

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -75,6 +75,8 @@ www.tivi.fi##div#skyscraper-height-div > aside > a:has-text(Kaupallinen yhteisty
 www.tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > div > aside > a:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > div > section > div:has-text(Kaupallinen yhteistyö)
+www.tivi.fi##:xpath(//span[contains(text(),"Kaupallinen yhteistyö")]/../../../..)
+www.tivi.fi##:xpath(//h2[contains(text(),"Kaupallinen yhteistyö")]/../..)
 
 ! uusisuomi.fi - Kaupallinen yhteistyö
 www.uusisuomi.fi##div#skyscraper-height-div > div > main > div > a:has-text(Kaupallinen yhteistyö)

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -73,7 +73,6 @@ www.tivi.fi##.teaser-partner-blog:has-text(KAUPALLINEN YHTEISTYÖ: )
 www.tivi.fi##.section-partner:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > aside > a:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
-www.tivi.fi##div#skyscraper-height-div > section > div:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > div > aside > a:has-text(Kaupallinen yhteistyö)
 www.tivi.fi##div#skyscraper-height-div > div > section > div:has-text(Kaupallinen yhteistyö)
 


### PR DESCRIPTION
Oh crap. This rule works perfectly for sponsored articles on the front page, but causes problems on subpages: `https://www.tivi.fi/uutiset` it removes all the news if there are at least one sponsored article among them. And of course there are.

Things are getting harder clearly :D I wonder if it's possible to apply blocking rules or whitelists for subpages only... That would be needed unless someone finds a better way.

I did not encounter issues on other sites that I have added lastly.

Edit, got some help. I have now new and improved filters, which block things correctly without issues:

`tivi.fi##:xpath(//span[contains(text(),"Kaupallinen yhteistyö")]/../../../..)`
`tivi.fi##:xpath(//h2[contains(text(),"Kaupallinen yhteistyö")]/../..)`