### PR TITLE
almacr - no reason to block it, legit banner

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -140,7 +140,6 @@ tyda.se#@#DIV[class*="advert"]
 ##div[id="bottomads"]
 ##div[class="ad__content"]
 ##div[class="ad-banner"]
-##div.ALMACR-container
 ##div[class="block-ad"]
 ##[href^="/artikkeli/kaupallinen-yhteistyo/"]
 ##[href^="https://online.adservicemedia.dk/cgi-bin/click.pl"]


### PR DESCRIPTION
This rule blocks a banner on the bottom of Alma Media owned domains (such as: `https://www.iltalehti.fi/`). That banner contains just links to other Alma Media services. It has no ads and it's not even annoying.