### PR TITLE
rantapallo.fi - sponsored ads and empty ad container on search results

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -427,6 +427,8 @@ rakentaja.fi##div[id="mast_liity_modal"]
 rakentaja.fi##img[id="js_ad"]
 rakentaja.fi##div[id="kauppa_hot"]
 rakentaja.fi##div[id^="banner"]
+rantapallo.fi###lomakone-results-horizontal-ads-3
+rantapallo.fi##.recommended.lomakone-results-row
 rantapallo.fi##div[class="optin-monster-saas-overlay"]
 sammysatv.com##center
 sammysatv.com##a[href*="banner"]


### PR DESCRIPTION
`https://www.rantapallo.fi/akkilahdot/`