### PR TITLE
iltalehti.fi co stuff and remnant bars

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -47,6 +47,8 @@ www.iltalehti.fi##div.mc-half-article:has-text(Kaupallinen yhteistyö)
 www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/terveys_palkki_vitaelab_kaupallinenyht.jpg"])
 www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat/nauhat/ky_asuminen_unikulma.jpg"])
 www.iltalehti.fi##.default.drfront-full-article:has([src*="assets.ilcdn.fi/kaupallinenyhteistyo"])
+www.iltalehti.fi##.default.drfront-full-article:has([src*="static.ilcdn.fi/kuvat/nauhat/ky_asuminen_sinituote.jpg"])
+www.iltalehti.fi##.title:xpath(//div[contains(text(), 'Kaupallinen yhteistyö')]):xpath(../../..)
 
 ! kauppalehti.fi - Commercial cooperation
 www.kauppalehti.fi##div#skyscraper-height-div > aside > aside > section > a:has-text(Kaupallinen yhteistyö)


### PR DESCRIPTION
The first rule blocks co article on the homepage: `https://www.iltalehti.fi/`

![Näyttökuva (8)](https://user-images.githubusercontent.com/17256841/65328512-29eac900-dbbf-11e9-90ee-8842dc2eadc6.png)

The second rule blocks some of those ugly bars `https://www.iltalehti.fi/kehon-hyvinvointi-ja-vitaepro` that are left behind after blocking commercial articles. That rule does not block everything but it's the best available now: `https://forums.lanik.us/viewtopic.php?p=149858#p149858`


