### PR TITLE
moottori.fi - ad article on the front page and on subpages

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -346,6 +346,8 @@ lansivayla.fi##DIV[class="region region-sidebar-first-bottom column sidebar"]
 mediagraph.com/*/log.gif
 mediagraph.com/*1x1.png
 moottori.fi##div[class*="torifi_banner"]
+moottori.fi##.kumppaniartikkeli-sidebar.smallfeature
+moottori.fi##.category-kumppaniartikkeli.moottori_kumppani.smallfeature
 moottoripyora.org###mainoskuva
 moottoripyora.org##DIV#topbanners
 moottoripyora.org##DIV#ad-top


### PR DESCRIPTION
Samples:

`https://moottori.fi/`
`https://moottori.fi/ajoneuvot/jutut/bmwn-huhutaan-irtisanovan-6-000-tyontekijaa-vuoteen-2022-osasyyna-rahantarve-autojen-sahkoistamiseen/`