### PR TITLE
hs.fi menokone

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -624,7 +624,8 @@ spring-tns.net$third-party
 ||herokuapp.com$third-party,domain=cultofmac.com
 ||hinta.fi/a/img/$image
 ||hintaopas.fi$third-party
-||hs.fi/kampanjat/menokone/mikameno.gif$image
+||hs.fi/kampanjat/menokone/*.jpg
+||hs.fi/kampanjat/menokone/*.gif
 ||honestpartners.com$third-party
 ||hymy.fi/wp-content/uploads/2018/03/HY_sivupalkin_myyntiviesti2.jpg$image
 ||improveads.fi^


### PR DESCRIPTION
They made a new picture with different file name for menokone. Asterisk cannot be used with "$image" so have to do things this way. I'll add more file formats if necessary.

`https://www.hs.fi/kampanjat/menokone/menokonenosto.jpg`