### PR TITLE
metropoli.net and sketsi.net ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -324,6 +324,9 @@ metropoli.net##DIV[id="ad-1000"]
 metropoli.net##LI[id*="_ad"]
 metropoli.net##a[href*="nordicbet"]
 metropoli.net##LI[class*="-ad"]
+metropoli.net###tdt_widget_minilanding-7
+metropoli.net##.tdt-desktop-ad.tdt-floating.tdt-manager-element
+metropoli.net##.widget_bs-text-listing-4.widget.primary-sidebar-widget.w-t.h-bg-f2861a.h-bg.h-c-ffffff.h-c.h-ni.article-popular-post-widget
 mikrobitti.fi##DIV[id="rosmo"]
 mobiili.fi##div[class="blogcontent"]>p:first-of-type
 mobiili.fi##div[class="blogcontent"]>p:nth-last-of-type(1)

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -325,7 +325,7 @@ metropoli.net##LI[id*="_ad"]
 metropoli.net##a[href*="nordicbet"]
 metropoli.net##LI[class*="-ad"]
 metropoli.net###tdt_widget_minilanding-7
-metropoli.net##.tdt-desktop-ad.tdt-floating.tdt-manager-element
+metropoli.net,sketsi.net##.tdt-desktop-ad.tdt-floating.tdt-manager-element
 metropoli.net##.widget_bs-text-listing-4.widget.primary-sidebar-widget.w-t.h-bg-f2861a.h-bg.h-c-ffffff.h-c.h-ni.article-popular-post-widget
 mikrobitti.fi##DIV[id="rosmo"]
 mobiili.fi##div[class="blogcontent"]>p:first-of-type

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -446,6 +446,8 @@ satakunnankansa.fi##DIV[class^="adContainer"]
 savonsanomat.fi##DIV[class="uutiskirje"]
 savonsanomat.fi##DIV[class*="customAd"]
 seiska.fi##div.article-ad-container
+sketsi.net##.tdt-minilanding.tdt-manager-element
+sketsi.net##footer > .container.tdt-ad-wrap
 sfnix.net/api/
 ! snstatic.fi/webstatic/*/desktop-all.js
 stream.almamedia.fi/mp/salsabanner


### PR DESCRIPTION
These filters block two separate ad widgets on the right side of the page and one banner on the bottom of the screen (appears after scrolling).

Sample link to test with: `https://www.metropoli.net/terveys-uutiset/krista-ei-ole-pystynyt-syomaan-kuukauteen-laakareiden-ei-tarvitse-hoitaa-heidan-mielestaan-minua-mitenkaan/`

For sketsi.net: added a filter for the banner on the bottom of the screen and sidebar widget and for an empty, low and wide ad container.

`https://sketsi.net/2019/09/oletko-ironian-ystava-katso-kuvat-ironian-malliesimerkeista/`