### PR TITLE
Problematic rule removed

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -694,7 +694,6 @@ spring-tns.net$third-party
 ||stats.fonecta.fi^
 ||taboola.com^
 ||tag.researchnow.com^
-||tags.tiqcdn.com/utag/*.js$domain=cnet.com|weather.com|greenmangaming.com,script
 ||tagsrvcs.com^
 ||telsu.fi$third-party
 ||ultimategracelessness.info^


### PR DESCRIPTION
- Causes subcategory breakage on cnet:

![Näyttökuva (3)](https://user-images.githubusercontent.com/17256841/65719549-b3623580-e0ae-11e9-90a8-137aafbee233.png)

- Doesn't activate on weather.com

- Only foreign sites. I did not notice problems on that gaming site but I consider this rule risky anyway.
