### PR TITLE
keskustelu.suomi24.fi

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -311,6 +311,7 @@ kukasoitti.com##DIV[class="main-bottom"]
 monster.almamedia.fi/nostobannerit/
 kelkkalehti.com/bannerit/
 keskustelu.suomi24.fi##div.center-block.no-padding.lt-res-below-2.ad-fluid.ad-container.ad.keskustelu-column3-ad
+keskustelu.suomi24.fi##.KJPUp.SeiskaRSSNews-sc-1l1e73s-4
 kuljetusnet.fi##div[id*="banner"]
 kuljetusnet.fi##div[class*="banner"]
 kuopionkirppari.fi##DIV[class*="banner"]


### PR DESCRIPTION
They have revised their site, conversation view is now diffent and it has that `seiska.fi` -news ad link on the right side of the page, again. (Similar to this: #129 )

Sample link: `https://keskustelu.suomi24.fi/t/16062243/maailma-vuonna-2029`