### PR TITLE
www.viikonloppu.com ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -544,6 +544,7 @@ vauva.fi###aldente-native01_0
 viikonloppu.com###text-10 > .textwidget
 viikonloppu.com###text-8
 viikonloppu.com###text-9
+viikonloppu.com###ticker
 viikonloppu.com##.tag-kasino.category-uutiset.sticky
 viikonloppu.com##.tag-rizk.category-uutiset.sticky
 viikonloppu.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoilla/"]

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -552,6 +552,7 @@ viikonloppu.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasi
 viikonloppu.com##[href="https://www.lainaovi.fi/lainalaskuri/"]
 viikonloppu.com##[href*="http://wlrizk.adsrv.eacdn.com/"]
 viikonloppu.com##[href*="https://record.twinaffiliates.com/"]
+viikonloppu.com##[href*="https://affmore.com"]
 voice.fi##div[class*="cxense-ad-container"]
 vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]
 pls.webtype.com/v.gif

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -547,6 +547,7 @@ viikonloppu.com###text-9
 viikonloppu.com###ticker
 viikonloppu.com##.tag-kasino.category-uutiset.sticky
 viikonloppu.com##.tag-rizk.category-uutiset.sticky
+viikonloppu.com##.tag-eurojackpot.category-uutiset.sticky
 viikonloppu.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoilla/"]
 viikonloppu.com##[href="https://www.lainaovi.fi/lainalaskuri/"]
 viikonloppu.com##[href*="http://wlrizk.adsrv.eacdn.com/"]

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -548,7 +548,8 @@ viikonloppu.com##.tag-kasino.category-uutiset.sticky
 viikonloppu.com##.tag-rizk.category-uutiset.sticky
 viikonloppu.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoilla/"]
 viikonloppu.com##[href="https://www.lainaovi.fi/lainalaskuri/"]
-viikonloppu.com##[href^="http://wlrizk.adsrv.eacdn.com/C.ashx"]
+viikonloppu.com##[href*="http://wlrizk.adsrv.eacdn.com/"]
+viikonloppu.com##[href*="https://record.twinaffiliates.com/"]
 voice.fi##div[class*="cxense-ad-container"]
 vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]
 pls.webtype.com/v.gif

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -541,6 +541,14 @@ uutissuora.fi##div[class="td-all-devices"]
 vaalikone.fi/*/preheat
 vauva.fi###aldente-contentfeedhigh_0
 vauva.fi###aldente-native01_0
+viikonloppu.com###text-10 > .textwidget
+viikonloppu.com###text-8
+viikonloppu.com###text-9
+viikonloppu.com##.tag-kasino.category-uutiset.sticky
+viikonloppu.com##.tag-rizk.category-uutiset.sticky
+viikonloppu.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoilla/"]
+viikonloppu.com##[href="https://www.lainaovi.fi/lainalaskuri/"]
+viikonloppu.com##[href^="http://wlrizk.adsrv.eacdn.com/C.ashx"]
 voice.fi##div[class*="cxense-ad-container"]
 vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]
 pls.webtype.com/v.gif


### PR DESCRIPTION
- Ad bar on the right side
- Ad links during article
- Loan and casino links at the bottom of the page
- Loan calculator and casino tabs at the top
- Ad articles
- Ad ticker remnant at the bottom

Sample links: `https://www.viikonloppu.com/`
`https://www.viikonloppu.com/isa-otti-kuvan-1-vuotiaasta-pojastaan-kuvasta-paljastui-karmiva-yksityiskohta/`
`https://www.viikonloppu.com/huijarimies-yritti-lavastaa-tapaturman-vakuutusyhtion-tyontekija-nauroi-vedet-silmissa/`
`https://www.viikonloppu.com/feissarimokat-tyouupumuksesta-karsiva-maarit-haluaa-saada-toita/`