### PR TITLE
vauva.fi - needless empty spaces (ad container remnant?)

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -541,6 +541,7 @@ uutissuora.fi##div[class="td-all-devices"]
 vaalikone.fi/*/preheat
 vauva.fi###aldente-contentfeedhigh_0
 vauva.fi###aldente-native01_0
+vauva.fi##div.cts-row-wrapper
 voice.fi##div[class*="cxense-ad-container"]
 vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]
 pls.webtype.com/v.gif


### PR DESCRIPTION
Before:

![Näyttökuva (21)](https://user-images.githubusercontent.com/17256841/67148597-d943ba00-f2a9-11e9-9a16-4be34ce22a78.png)

After:

![Näyttökuva (22)](https://user-images.githubusercontent.com/17256841/67148599-dfd23180-f2a9-11e9-9a2e-09214551c2aa.png)

A sample link: `https://www.vauva.fi/keskustelu/3577633/miksi-kodinhoidontukea-taas-leikataan-eli-summat-vahenee-kyl-taa-outo-yhteiskunta?changed=1571501458` (scroll to almost bottom where you can see "latest" topics.)

