### PR TITLE
www.mtvuutiset.fi ad containers

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -395,6 +395,7 @@ mtv.fi/static/javascripts/external-js/*.js
 mtv.fi##div[class="leaderboard"]
 mtv.fi##DIV[class*="ad-container"]
 mtvuutiset.fi###leaderboard-2
+mtvuutiset.fi##.ad-container.banner
 mtvuutiset.fi##.ad_fadein
 mtvuutiset.fi##.component-adincontent.component
 mtvuutiset.fi##.leaderboard-1.leaderboard


### PR DESCRIPTION
Sample: `https://www.mtvuutiset.fi/makuja/artikkeli/ville-hehkuttaa-superhelppoa-ja-halpaa-arkiruokaa-suosittelee-myos-tumpeloille-tyttoystavanikin-osaisi-tehda-tata/7592510`

Ad containers inside articles.