### PR TITLE
ampparit.com ticker

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -173,11 +173,8 @@ aijaa.com##[href^="http://www.kumiukko.fi/ostos/"]
 aijaa.com##[href^="https://store.iittala.fi/_ui/tt/index.html"]
 alibi.fi##.magazineorderwidget__content
 almamedia.fi/alma-logo-pieni.png
-ampparit.com##.ticker_ad.ticker
-ampparit.com##div[class="header"]>div:first-child
-ampparit.com##div[class="ampparit-ticker"]
 ampparit.com##DIV[class*="ad-"]
-ampparit.com##.ticker2--bottom.ticker2
+ampparit.com##div[class*="ticker"]
 anna.fi##div[class*="sisaltoyhteistyo"]
 arcticinsider.com##a[href*="bannerTrack"]
 arvopaperi.fi##DIV[class="interstitial"]


### PR DESCRIPTION
Made more general filter `ampparit.com##div[class*="ticker"]` that will block all elements that have a word "ticker". I'll make it this way because the name of the bottom ticker have partially changed many times and has changed again.

Also removed obsolete `ampparit.com##div[class="header"]>div:first-child` filter.