### PR TITLE
vapaasana.swedishforum.net top ad container hide

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -129,6 +129,7 @@ anna.fi##article[class^="grid__item_"]:has(.list-tag_commercial)
 kotiliesi.fi##article[class^="grid__item_"]:has(.template-item_nativead)
 kipparilehti.fi##article[class^="grid__item_"]:has(.js-native-link)
 venelehti.fi##article[class^="grid__item_"]:has(.bg-category_mainos)
+vapaasana.swedishforum.net###main-content:style(margin-top: -100px !important;)
 
 savonsanomat.fi,ess.fi,itahame.fi,ksml.fi##+js(setTimeout-defuser.js,linkEl)
 


### PR DESCRIPTION
Sample link: `http://vapaasana.swedishforum.net/t2570-pienia-ituja`

This kind of rule is of course unusual way to fix this but that empty ad container is not easy to hide in other way. The id of that ad container changes on every page refresh to have to be creative :) This fix works without an issue.