### PR TITLE
Sanoma Oyj video ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -847,9 +847,7 @@ www.vr.fi##.headerContents > .infoMessages
 ! Sanoma Oyj video ads
 ||dwk14raokkwxv.cloudfront.net/sanomafi/media/*.mp4$media
 ||nelonenmedia.fi/ads/$media
-||nelonenmedia-pmd-ads-manual.nm-stream.nelonenmedia.fi/$media
-||nelonenmedia-pmd-ads-spotgate.nm-stream.nelonenmedia.fi/$media
-||nelonenmedia-pmd-ads-audio.nm-stream.nelonenmedia.fi/$media
+||nelonenmedia-pmd-ads-*.nm-stream.nelonenmedia.fi/$media
 
 ! unbreak "Suosituimmat" ("most popular") on mtvuutiset.fi
 @@leiki.com/mtv3/widgets/loader/$domain=mtvuutiset.fi


### PR DESCRIPTION
I encountered a new adserver, which was `https://nelonenmedia-pmd-ads-promo.nm-stream.nelonenmedia.fi`, here: `https://www.ruutu.fi/video/3505160`

I however realised that I could make a general filter instead of having many separate filters since those adservers all follow the same pattern.