### PR TITLE
iltalehti.fi empty ad container at the bottom of all scrollable articles

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -271,6 +271,7 @@ high.fi##div[class*="sub-container"]
 hinta.fi##div[class="hv-wrapper-right-item"]
 hinta.fi##div[class="hv-wrapper-left-item"]
 ilkka.fi/logger
+iltalehti.fi##.center.category-list-embed.is-visible.LazyLoad
 iltalehti.fi##div[class*="parade-ad-container"]
 iltalehti.fi##.slider-content
 iltalehti.fi##div[class="iframe-container"]


### PR DESCRIPTION
![Näyttökuva (97)](https://user-images.githubusercontent.com/17256841/69900057-c37ce680-1377-11ea-92de-5488c4fc7732.png)
