### PR TITLE
iltalehti co stuff

### DIFF
--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -51,6 +51,7 @@ www.iltalehti.fi##.default.drfront-full-article:has([src*="ilcdn.fi/kuvat/nauhat
 www.iltalehti.fi##.default.drfront-full-article:has([src*="ilcdn.fi/kuvat/nauhat/ky_"])
 www.iltalehti.fi##.default.drfront-full-article:has([src*="ilcdn.fi/ky-"])
 www.iltalehti.fi##.default.drfront-full-article:has([src*="ilcdn.fi/ky_"])
+www.iltalehti.fi##.default.drfront-full-article:has([src*="ilcdn.fi/mainosnauhta"])
 www.iltalehti.fi##.default.drfront-full-article:has([href*="clark-taloutesi-tukena"])
 
 ! kauppalehti.fi - Commercial cooperation


### PR DESCRIPTION
![kuva](https://user-images.githubusercontent.com/17256841/70915245-2fbb4380-2022-11ea-91e4-7c79e1598d07.png)

It's funny how I recently took this rule off as the address wasn't working anymore: `https://assets.ilcdn.fi/mainosnauhta_digi_hintaopas.jpg` but now it's back in business. :D made a generalized rule of it.