### PR TITLE
hs.fi ad

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -226,6 +226,7 @@ gamereactor.fi##div[id="eventad"]
 hardware.fi##DIV[class="top-ad-space"]
 hbl.fi##ksf-adblockers
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[class*="lyads"]
+hs.fi##.for-no-subscription.html-is-seuraa-myynti-bf.html-is-seuraa-myynti
 hs.fi###aldente-mobibanner01_0
 hs.fi###aldente-mobibanner02_0
 hs.fi###aldente-mobicontentfeedhigh_0


### PR DESCRIPTION
![kuva](https://user-images.githubusercontent.com/17256841/71191007-4960c300-228e-11ea-9086-24900a969182.png)

Note: that banner is visible only at times. Now it's not there anymore. They sometimes activate it and sometimes disable it.
