### PR TITLE
Pirmedia Oy ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -171,6 +171,8 @@ aijaa.com##[href^="http://www.apteekkituotteet.fi/WebRoot/Euran/Shops/Eura/Media
 aijaa.com##[href^="http://www.hiusverkko.fi/tt/hiusverkko/"]
 aijaa.com##[href^="http://www.kumiukko.fi/ostos/"]
 aijaa.com##[href^="https://store.iittala.fi/_ui/tt/index.html"]
+akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##[href="/tilaa-lehti"]
+akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##.om-one.omamainos-products
 alibi.fi##.magazineorderwidget__content
 almamedia.fi/alma-logo-pieni.png
 ampparit.com##DIV[class*="ad-"]
@@ -420,6 +422,7 @@ offroadpro.fi,mpmaailma.fi##div[id="googlePlusOne"]
 offroadpro.fi,mpmaailma.fi##div[id="logo-area"]
 offroadpro.fi,mpmaailma.fi##div[id^="block-ad"]
 offroadpro.fi/*/ad/serve.php
+orivedensanomat.fi##.CMAC_AdChangerWidget.widget
 api.pinterest.com/*/count.json
 mpmaailma.fi/*/ad/serve.php
 pastebin.com##div#abrpm


### PR DESCRIPTION
`akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##[href="/tilaa-lehti"]` - This rule blocks "tilaa lehti" ad.

`akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##.om-one.omamainos-products` - This rule blocks ad banner on the right side

`akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##.om-row.om-three.omamainos-products` - This rule blocks ads inside articles at the top. Samples:

https://akaanseutu.fi/2019/12/23/pelastuslaitos-toivottaa-turvallista-joulun-aikaa-ohjeiden-kera-nain-sailytat-juhlamielen-ja-kotisi/#b9b021c7

https://lvs.fi/2019/12/27/uusi-vuosi-uudet-lupaukset/#d9ec1bb0

https://shl.fi/sarjakuvat/ralph-18-12-2019/

https://ylojarvenuutiset.fi/2019/12/27/missa-on-80-vuotias-antero-takala/#14825717

`orivedensanomat.fi##.CMAC_AdChangerWidget.widget` - This rule blocks ads on the right side