### PR TITLE
Old rules removed

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -159,13 +159,6 @@ aamulehti.fi###promo-2
 aamuset.fi##DIV#block-views-etusivukaruselli-block
 aamuset.fi##DIV#block-views-mainoskaruselli-block
 aamuset.fi##DIV[class="adslist"]
-abounderrattelser.fi,åu.fi##DIV[class^="paszone"]
-abounderrattelser.fi,åu.fi##DIV[class*="proadszone"]
-abounderrattelser.fi,åu.fi##SECTION[class*="flexslider"]
-abounderrattelser.fi,åu.fi##DIV[class="jetpack-image-container"]
-abounderrattelser.fi,åu.fi##DIV[class="PasPopupCont"]
-abounderrattelser.fi,åu.fi##DIV[id="backgroundPasPopup"]
-abounderrattelser.fi,åu.fi##div[id*="popmake"]
 aijaa.com##[href*="tradetracker"]
 aijaa.com##[href^="http://www.apteekkituotteet.fi/WebRoot/Euran/Shops/Eura/MediaGallery/"]
 aijaa.com##[href^="http://www.hiusverkko.fi/tt/hiusverkko/"]


### PR DESCRIPTION
abounderrattelser.fi does not have any DOM rules activated by Finnish Easylist anymore, I clicked through many subpages.
åu.fi redirects to previous domain