### PR TITLE
Removed too general, problematic and English rule

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -38,7 +38,6 @@
 /om-mainosputki/
 /pagestat?
 /sivulaskuri
-smartbanner
 /sponsorit.
 /sponsorit/*
 /sponsorit_


### PR DESCRIPTION
This filter

`smartbanner`

Should be in my opinion deleted. It's too general and it's name isn't Finnish so rules like this would do better in the English Easylist anyway. It also causes issues:

https://github.com/AdguardTeam/AdguardFilters/issues/46924

I tested that issue and confirmed that it's there.