### PR TITLE
Redundant rules - covered by main Easylist

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -103,7 +103,6 @@ nelonenmedia.fi/hitcounter
 ##.yhteistyossa
 ##.ylamainokset
 ##.ylamainos
-###rhs_block > #mbEnd
 ##DIV[class*="newsFrontAd"]
 ##DIV[class="AgAdCarousel_Container"]
 ##DIV[class="AgAdCarousel_LightBox"]
@@ -123,7 +122,6 @@ tyda.se#@#DIV[class*="advert"]
 ##DIV[class="banner-top"]
 ##a[href*="/clickthrgh.asp?"]
 ##DIV[id="top-ad"]
-##DIV[id="ads-top"]
 ##DIV[id^="ads-content-bottom"]
 ##div[class="ad-wrapper"]
 ##td[class="adbanner"]
@@ -149,7 +147,6 @@ aamulehti.fi###promo-1
 aamulehti.fi###promo-2
 aamuset.fi##DIV#block-views-etusivukaruselli-block
 aamuset.fi##DIV#block-views-mainoskaruselli-block
-aamuset.fi##DIV[class="adslist"]
 aijaa.com##[href*="tradetracker"]
 aijaa.com##[href^="http://www.apteekkituotteet.fi/WebRoot/Euran/Shops/Eura/MediaGallery/"]
 aijaa.com##[href^="http://www.hiusverkko.fi/tt/hiusverkko/"]
@@ -183,8 +180,6 @@ careers.sstatic.net/careers/gethired/
 careers.stackoverflow.com/ad/
 cultofmac.com##div[class="stackCommerceItemWrap"]
 cultofmac.com##div[id*="-ad"]
-demokraatti.fi##div[class="topads"]
-demokraatti.fi##div[class="ad-item"]
 demokraatti.fi##div[class^="at-share-dock-outer"]
 demokraatti.fi##div[class="offer"]
 demokraatti.fi##div[class*="proads"]
@@ -202,7 +197,6 @@ feissarimokat.com##DIV[class="adbox-large"]
 feissarimokat.com##DIV[class="adbox-smaller nextpal"]
 feissarimokat.com##LI[class*="shopster"]
 gamereactor.fi##div[id="eventad"]
-hardware.fi##DIV[class="top-ad-space"]
 hbl.fi##ksf-adblockers
 helsinginuutiset.fi,vihdinuutiset.fi##DIV[class*="lyads"]
 hs.fi##.for-no-subscription.html-is-seuraa-myynti-bf.html-is-seuraa-myynti
@@ -279,8 +273,7 @@ kansanuutiset.fi##.intextad.clearfix.cb-module-block.cb-box.cb-a-large
 kansanuutiset.fi##A[href="http://www.autonvaraosastore.fi/"]
 kansanuutiset.fi##div[class*="intextad"]
 karjalainen.fi##center
-kansi.a-lehdet.fi/spring.js
-adslm.a-lehdet.fi/www/delivery/ 
+kansi.a-lehdet.fi/spring.js 
 kauppalehti.fi/blank.gif
 kauppalehti.fi/*/kl.gif
 kauppalehti.fi/*/spring.js
@@ -344,7 +337,6 @@ moottori.fi##.kumppaniartikkeli-sidebar.smallfeature
 moottori.fi##.category-kumppaniartikkeli.moottori_kumppani.smallfeature
 moottoripyora.org###mainoskuva
 moottoripyora.org##DIV#topbanners
-moottoripyora.org##DIV#ad-top
 moottoripyora.org##li[id*="navbar_notice_"]
 moottoripyora.org##LI[class="first cooperation nebula"]
 moottoripyora.org/img/cooperation-nebula.png
@@ -353,9 +345,6 @@ motouutiset.fi##DIV[class*="ad-panorama"]
 motouutiset.fi##DIV[class*="ad-giant"]
 motouutiset.fi##a[href*="revads"]
 motouutiset.fi##DIV[class*="cc-window cc-banner cc-type-info "]
-revads.motouutiset.fi/www/delivery/lg.php
-revads.motouutiset.fi/www/delivery/spc.php
-revads.motouutiset.fi/www/delivery/spcjs.php
 murobbs.muropaketti.com##DIV[class="om-container"]
 murobbs.muropaketti.com##a[href*="emediate"]
 murobbs.muropaketti.com##DIV[class="funboxWrapper"]
@@ -564,7 +553,6 @@ viikonloppu.com##[href*="https://record.twinaffiliates.com/"]
 viikonloppu.com##[href*="https://affmore.com"]
 viikonloppu.com##[href*="https://tracker-pm2.fortunelegends.com/"]
 voice.fi##div[class*="cxense-ad-container"]
-vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]
 pls.webtype.com/v.gif
 ylilauta.org##a[href="/kultatili"]
 xracing.fi##DIV[id="inner_commerce_container"]
@@ -923,7 +911,6 @@ www.finder.fi##.Advertisement__Box
 
 ! links to ad servers
 ##[href^="https://clk.tradedoubler.com/click"]
-##[href^="https://tc.tradetracker.net/"]
 
 ! io-tech.fi
 bbs.io-tech.fi###premiumi


### PR DESCRIPTION
Easylist Finland rule on the left, main Easylist rule on the right.

`###rhs_block > #mbEnd` - already in the main Easylist

`##DIV[id="ads-top"]` - covered by `###ads-top`

`##[href^="https://tc.tradetracker.net/"]` - by `##a[href^="https://tc.tradetracker.net/"]`

`moottoripyora.org##DIV#ad-top` - by `###ad-top`

`demokraatti.fi##div[class="ad-item"]` - by `##.ad-item`

`aamuset.fi##DIV[class="adslist"]` by `##.adslist`

`vihreat.fi##DIV[id="block-simpleads-sidebar-ads"][class="block block-simpleads"]` by `##.block-simpleads`

`hardware.fi##DIV[class="top-ad-space"]` by `##.top-ad-space`

`demokraatti.fi##div[class="topads"]` by `##.topads`

`adslm.a-lehdet.fi/www/delivery/` by `/www/delivery/*`

`revads.motouutiset.fi/www/delivery/lg.php` by `/www/delivery/*`

`revads.motouutiset.fi/www/delivery/spc.php` by `/spc.php`

`revads.motouutiset.fi/www/delivery/spcjs.php` by `/spcjs.php`