### PR TITLE
www.audiovideo.fi ads

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -166,6 +166,8 @@ arcticinsider.com##a[href*="bannerTrack"]
 arvopaperi.fi##DIV[class="interstitial"]
 arvopaperi.fi##DIV[class="samTop"]
 arvopaperi.fi##DIV[class="topMostBanners"]
+audiovideo.fi##.head.the-wrap
+audiovideo.fi###bunyad-widget-ads-3
 audiovideo.fi##DIV[id*="mainospaikka"]
 audiovideo.fi##DIV[class*="mainospaikka"]
 autotie.fi##div.facebook-wrapper


### PR DESCRIPTION
Sample link: https://www.audiovideo.fi/testi/benq-w2700-4k-uhd-dlp-videotykki-testissa/

- Main ad wrap on the top
- Ad banner on the right side (note, I left there one banner since it's not an ad, it's just a link to "reviews" area.