### PR TITLE
lapinkansa - ad container remnant

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -299,6 +299,7 @@ keskustelu.suomi24.fi##[class*="SeiskaRSSNews"]
 kuljetusnet.fi##div[id*="banner"]
 kuljetusnet.fi##div[class*="banner"]
 kuopionkirppari.fi##DIV[class*="banner"]
+lapinkansa.fi###content1-container
 lapinkansa.fi###outstream-container
 lapinkansa.fi###paraati-ad-grid
 loimaanlehti.fi##div[class*="pro_ad_adzone"]


### PR DESCRIPTION
![kuva](https://user-images.githubusercontent.com/17256841/72226201-1660d500-3597-11ea-9a02-6dcbe3d62893.png)

Sample link: https://www.lapinkansa.fi/analyysi-iran-tunnusti-tuhonneensa-vahingossa-ohju/526274 (end of article)