### PR TITLE
Cookie info subpage blocked by Annoyance / Cookie list

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -978,6 +978,7 @@ tjareborg.fi#@#.push-container
 @@/wp-content/*twitter.jpg$domain=tekniikanmaailma.fi
 ! ville.utu.fi unbreak
 @@||*/icons/google$image,domain=utu.fi
+@@||cookieinformation.com/$script,domain=kotimikro.fi
 
 ! -----UNBREAK END-----
 


### PR DESCRIPTION
https://kotimikro.fi/evastepolitiikka This link does not open because of Fanboy's Annoyance / cookie list. That's a legit, separate cookie info subpage, that shouldn't be blocked in my opinion.