### PR TITLE
iltalehti.fi - new ad article container

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -256,6 +256,7 @@ iltalehti.fi##.center.category-list-embed.is-visible.LazyLoad
 iltalehti.fi##div[class*="parade-ad-container"]
 iltalehti.fi##.slider-content
 iltalehti.fi##div[class="iframe-container"]
+iltalehti.fi##div.fp-container.card
 @@||leiki.com$domain=iltalehti.fi
 isup.me##div[class="smile-container"]
 static.iltalehti.fi/*/spring


### PR DESCRIPTION
This is used on some Iltalehti subpages. Samples:

https://www.iltalehti.fi/asuminen
https://www.iltalehti.fi/matkailu
https://www.iltalehti.fi/digi