### PR TITLE
hs.fi rule generalization

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -654,7 +654,7 @@ spring-tns.net$third-party
 ||hs.fi/kampanjat/menokone/*.jpg
 ||hs.fi/kampanjat/menokone/*.gif
 ||hs.fi/menokone/menokonenosto.*
-||kampanjat.hs.fi/Nostokuvat/
+||kampanjat.hs.fi/
 ||honestpartners.com$third-party
 ||hymy.fi/wp-content/uploads/2018/03/HY_sivupalkin_myyntiviesti2.jpg$image
 ||improveads.fi^


### PR DESCRIPTION
I encountered a mobile ad container (that empty grey area), that's why this rule needs generalization.

![Screenshot_20200115-073503](https://user-images.githubusercontent.com/17256841/72408195-c5093f00-376a-11ea-9fa3-672056cf7fe8.png)

( `||kampanjat.hs.fi/Maailma2020/Maailma-2020-mobiili-c.html$subdocument` )

