### PR TITLE
iltalehti broken, urgent fix

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -253,7 +253,6 @@ iltalehti.fi##.center.category-list-embed.is-visible.LazyLoad
 iltalehti.fi##div[class*="parade-ad-container"]
 iltalehti.fi##.slider-content
 iltalehti.fi##div[class="iframe-container"]
-iltalehti.fi##div.fp-container.card
 @@||leiki.com$domain=iltalehti.fi
 isup.me##div[class="smile-container"]
 static.iltalehti.fi/*/spring


### PR DESCRIPTION
This recently added rule removes now iltalehti article containers on the frontpage. They have changed things as last time this rule didn't block stuff on the frontpage, just some ad articles on some subpages, I checked it when I recently added this rule.