### PR TITLE
Finland_adb.txt: add rule for tori.fi middle-page campaign

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,5 +1,5 @@
 [Adblock Plus 2.0]
-! Version: 26March2020v1
+! Version: 28March2020v1
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
 ! Expires: 4 days
@@ -437,6 +437,7 @@ www.is.fi##.border-b.lg\:w-main-lane.bg-is-ad-blue.mb-16
 www.is.fi##.ml-16.lg\:block.w-right.hidden > .border-b.lg\:w-main-lane.bg-is-ad-blue.mb-16
 www.is.fi##.overflow-hidden.relative.aspect-ratio-container.jsx-3817070661
 www.is.fi##div.sadblob-loading
+www.tori.fi###campaign_middle
 www.tori.fi###footer_partner_links
 www.tori.fi##DIV[id="banner_panorama_topmost"]
 www.tori.fi##DIV[id="panorama_top"]


### PR DESCRIPTION
I think it qualifies to be blocked. To verify: check Asunnot in tori \<https://www.tori.fi/koko_suomi/asunnot >, somewhere in the middle of the page, you see car offers. 