### PR TITLE
Converted ":has"/":has-text" entries into ABP equivalents for broader entry support in adblockers

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,5 +1,5 @@
 [Adblock Plus 3.4]
-! Version: 30June2020v1
+! Version: 01July2020v1
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
 ! Expires: 4 days
@@ -113,12 +113,14 @@ _mainosnappi.
 
 aamulehti.fi###promo-1
 aamulehti.fi###promo-2
-aamulehti.fi,satakunnankansa.fi,valkeakoskensanomat.fi,nokianuutiset.fi,janakkalansanomat.fi,kmvlehti.fi,jamsanseutu.fi,suurkeuruu.fi,kankaanpaanseutu.fi,rannikkoseutu.fi,tyrvaansanomat.fi,merikarvialehti.fi,sydansatakunta.fi##.parade-ad.ad
 aamulehti.fi##div.adContainer
+aamulehti.fi#?#DIV[id*="pipe"] > div > div:-abp-contains(Kaupallinen yhteistyö)
+aamulehti.fi#?#DIV[id^="morearticles_"]:-abp-has(h2:-abp-has(span:-abp-contains(Kaupallinen yhteistyö)))
 aamulehti.fi,satakunnankansa.fi,janakkalansanomat.fi,sydansatakunta.fi,jamsanseutu.fi,kankaanpaanseutu.fi,kmvlehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,suurkeuruu.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi###bottomBanner
+aamulehti.fi,satakunnankansa.fi,valkeakoskensanomat.fi,nokianuutiset.fi,janakkalansanomat.fi,kmvlehti.fi,jamsanseutu.fi,suurkeuruu.fi,kankaanpaanseutu.fi,rannikkoseutu.fi,tyrvaansanomat.fi,merikarvialehti.fi,sydansatakunta.fi##.parade-ad.ad
 aijaa.com##div.text-center.col-sm-6 > a[rel$="nofollow"]
-akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##div[class*="omamainos"]
 akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##[href="/tilaa-lehti"]
+akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##div[class*="omamainos"]
 aksa.fi##div[class*="adverts"]
 aksa.fi##div[class*="g-single a-"]
 alastonsuomi.com##.jb
@@ -135,6 +137,10 @@ anna.fi##div.grid__item_tn-1-2
 arcticinsider.com##a[href*="bannerTrack"]
 arvopaperi.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="/kumppaniblogit/"]
 arvopaperi.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="https://studio.arvopaperi.fi/"]
+arvopaperi.fi#?#div#skyscraper-height-div > aside > div > a:-abp-contains(Kaupallinen yhteistyö)
+arvopaperi.fi#?#div#skyscraper-height-div > aside > div > div:-abp-contains(Kaupallinen yhteistyö)
+arvopaperi.fi#?#div#skyscraper-height-div > div > aside > div > a:-abp-contains(Kaupallinen yhteistyö)
+arvopaperi.fi#?#div#skyscraper-height-div > div > div > div > div > div > a:-abp-contains(Kaupallinen yhteistyö)
 asunnot.oikotie.fi##.customer-color-link.sahkovertailu-campaign__link
 audiovideo.fi###bunyad-widget-ads-3
 audiovideo.fi##.head.the-wrap
@@ -192,14 +198,16 @@ hinta.fi##div[class="hv-wrapper-left-item"]
 hinta.fi##div[class="hv-wrapper-right-item"]
 hintaseuranta.fi##.header-container__ad-container
 historianet.fi##div[id="stickyFooter"]
-hs.fi##[id^="aldente-mobi"]
 hs.fi##.aldente-wrapper
 hs.fi##.for-no-subscription.html-is-seuraa-myynti-bf.html-is-seuraa-myynti
 hs.fi##.hs-advertorial
 hs.fi##.lg\:w-main-lane.bg-hs-frost.mb-16
+hs.fi##[id^="aldente-mobi"]
+hs.fi##a.block[href*="/mainos/"]
 hs.fi##DIV[class*="-ad-block"]
 hs.fi##DIV[class*="ad-container"]
-hs.fi##a.block[href*="/mainos/"]
+hs.fi#?#.embedded:-abp-contains(Markkinapaikka)
+hs.fi#?#article:-abp-has(a[href^="https://tilaa.sanoma.fi/hs-digi"])
 hs.fi,web.archive.org##.bottomsticky-body.fixed.bottomsticky-mounted.metered-softwall-shadow.xl\:pr-sideAdOffset
 huoltovalikko.com##A[href="http://www.satshop.fi"]
 huuto.net##div.grid-element-container-hintaseuranta.grid-element-container
@@ -214,14 +222,37 @@ iltalehti.fi##.slider-content
 iltalehti.fi##div.footer-wrapper__item.is-visible.LazyLoad
 iltalehti.fi##div[class*="parade-ad-container"]
 iltalehti.fi##div[class="iframe-container"]
+iltalehti.fi#?#.article-container:-abp-contains(Kaupallinen yhteistyö)
+iltalehti.fi#?#.card:-abp-contains(kaupallinen yhteistyö)
+iltalehti.fi#?#.card:-abp-has(.block > a[class="nakoislehti"][href^="https://plus.iltalehti.fi/nakoislehti/"])
+iltalehti.fi#?#.card:-abp-has(.full-article:-abp-contains(Kaupallinen yhteistyö))
+iltalehti.fi#?#.card:-abp-has(.half-article:-abp-contains(Kaupallinen yhteistyö)):not(:-abp-has(.half-article:not(:-abp-contains(Kaupallinen yhteistyö))))
+iltalehti.fi#?#.half-article:-abp-contains(Kaupallinen yhteistyö)
+iltalehti.fi#?#a.small-article:-abp-contains(Kaupallinen yhteistyö)
+iltalehti.fi#?#div.fp-container.card:-abp-contains(Kaupallinen yhteistyö)
+iltalehti.fi#?#div.fp-container.card:-abp-has([href*="clark-taloutesi-tukena"])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/*kaupallinenyht*" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/*mainosnauha" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/asuminen_vattenfall_palkki"])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/kuvat/nauhat/ky_" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/kuvat/nauhat/nauha_ky_" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/kuvat/nauhat/nauha_terveys_specsavers"])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/ky-" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/ky_" i])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/mainosnauhta"])
+iltalehti.fi#?#div.fp-container.card:-abp-has([src*="ilcdn.fi/Nauha_Rantapallo"])
+iltalehti.fi#?#div.is-visible.LazyLoad:-abp-contains(kaupallinen yhteistyö)
 iltapulu.fi##div[class="footer-ylempi"]
-io-tech.fi###text-3
-io-tech.fi###text-7
-io-tech.fi##[href^="https://www.io-tech.fi/io/www/dlvr/tick.php"]
-irc-galleria.net##div[id^="open_"]
 inssinosingot.fi##.block-mainos
 inssinosingot.fi##.button-mainos
 inssinosingot.fi##.footer-1.footer.footer-widgets
+inssinosingot.fi#?#div[class="row align-center"]:-abp-has([class$="lazy-load-active"])
+io-tech.fi###text-3
+io-tech.fi###text-7
+io-tech.fi##[href^="https://www.io-tech.fi/io/www/dlvr/tick.php"]
+io-tech.fi#?#div.artikkeli-slide:-abp-has([src*="-nosto"])
+io-tech.fi#?#div.artikkeli-slide:-abp-has([src*="samsung-ssd8-10-240x160_center_center.jpg"])
+irc-galleria.net##div[id^="open_"]
 jatkoaika.com##div[class="block block-block"]
 juoksufoorumi.fi##[data-blockid="app_cms_Blocks_3p8fros91"]
 juoksufoorumi.fi##[data-blockid="app_cms_Blocks_mkpb5gdld"]
@@ -252,25 +283,32 @@ kansanuutiset.fi##div[class*="intextad"]
 karjalainen.fi,sammysatv.com##center
 kauppalehti.fi##div[class="adcontainer"]
 kauppalehti.fi##iframe[class*="adcontainer"]
+kauppalehti.fi#?#div#skyscraper-height-div > aside > aside > section > a:-abp-contains(Kaupallinen yhteistyö)
+kauppalehti.fi#?#div#skyscraper-height-div > aside > section > a:-abp-contains(Kaupallinen yhteistyö)
+kauppalehti.fi#?#div#skyscraper-height-div > div > aside > aside > section > a:-abp-contains(Kaupallinen yhteistyö)
+kauppalehti.fi#?#div#skyscraper-height-div > div > main > a:-abp-contains(Kaupallinen yhteistyö)
+kauppalehti.fi#?#div#skyscraper-height-div > main > aside > div > a:-abp-contains(Kaupallinen yhteistyö)
 keskipohjanmaa.fi##.ad-list.col-xs-12
 keskipohjanmaa.fi##div.hidden-xs.news-n.newslink-ad.col-xs-12
 keskustelu.suomi24.fi##[class*="SeiskaRSSNews"]
 keskustelu.suomi24.fi##[class*="StaraRSSNews"]
 keskustelu.suomi24.fi,kirkkojakaupunki.fi,luukku.com,mtvuutiset.fi,seiska.fi,studio55.fi##.ad-container
-kipparilehti.fi,kotiliesi.fi##[data-template-type="nativead"]
 kipparilehti.fi##[id="dfp__rectangle-1_1"][class="grid__item_1 grid__item_md-1-3"]
+kipparilehti.fi,kotiliesi.fi##[data-template-type="nativead"]
 koneporssi.com,urakointiuutiset.fi,ammattiautot.fi,konekuriiri.fi##.banners
 kotikokki.net###partners-container-big
 kotikokki.net##[id="content"][class="content hrecipe"] ~ [style="float: left; width: 100%; height: 200px; padding-left:20px; padding-right:20px; box-sizing:border-box; background-color:#fff;"]
 kotiliesi.fi##.article-continues
 kotimikro.fi##.campaign-teaser-show
 kotimikro.fi##b > [href^="https://tilaus.kotimikro.fi/brand/kotimikro/"]
-kukasoitti.com##DIV[class="main-bottom"]
 kukasoitti.com##a[href*='adsrv']
+kukasoitti.com##DIV[class="main-bottom"]
 kuljetusnet.fi###middle
 kuljetusnet.fi##div[class*="banner"]
 kulutusluottovertailu.fi##.fusion-carousel
 kuvake.net,nainen.com,viikonloppu.com###ticker
+laliiga.com,leijonat.com,nhlsuomi.com,suomifutis.com,suomikiekko.com,valioliiga.com#?#.td-post-content > h4:-abp-contains(talletusbonus)
+laliiga.com,leijonat.com,nhlsuomi.com,suomifutis.com,suomikiekko.com,valioliiga.com#?#.td-post-content > ol:-abp-contains(pelitili)
 lansivayla.fi##.card--native.card
 lapinkansa.fi###content1-container
 lapinkansa.fi###outstream-container
@@ -294,6 +332,9 @@ marmai.fi##div#skyscraper-height-div > aside > div > div > a[href^="/kumppaniblo
 marmai.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="/kumppaniblogit/"]
 marmai.fi##div#skyscraper-height-div > div > section > div > a[href^="/kumppaniblogit/"]
 marmai.fi##div#skyscraper-height-div > section > div > a[href^="/kumppaniblogit/"]
+marmai.fi#?#div#skyscraper-height-div > aside > a[href^="https://studio.marmai.fi/"]:-abp-contains(Kaupallinen yhteistyö)
+marmai.fi#?#div#skyscraper-height-div > div > aside > a[href^="https://studio.marmai.fi/"]:-abp-contains(Kaupallinen yhteistyö)
+marmai.fi#?#div#skyscraper-height-div > div > section > div > div > div:-abp-contains(Kaupallinen yhteistyö)
 matkaendurot.net##DIV[id="logodesc"]>table>tbody>tr>td:first-of-type
 matkaendurot.net##SPAN[id="banneripaikka"]
 mbnet.fi##DIV#topbanner
@@ -305,6 +346,7 @@ mediuutiset.fi##div#skyscraper-height-div > div > aside > div > a[href^="https:/
 mediuutiset.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="https://studio.mediuutiset.fi/"]
 mediuutiset.fi##div#skyscraper-height-div > div > section > a[href^="/kumppanisisaltoa/"]
 mediuutiset.fi##div#skyscraper-height-div > section > a[href^="/kumppanisisaltoa/"]
+mediuutiset.fi#?#div#root > div > div > div > div > div > div:-abp-contains(Kaupallinen Yhteistyö)
 menaiset.fi##.tagged-kaupallinen-yhteistyö.is-commercial.node-article-mini_teaser.node-mini_teaser.view-mode-mini_teaser.node-promoted
 mesta.net##.gofollow
 metropoli.net###menu-item-46797 > [href="https://www.metropoli.net/rahapelit/"]
@@ -323,27 +365,33 @@ mobiili.fi##.execphpwidget
 mobiili.fi##.single-content-all > div[style^="float:left"][style*="width:100%"][style*="text-align:center"][style*="margin-bottom:17px"]
 mobiili.fi##.singlehinta.header_ad
 mobiili.fi##img[src^="https://impr.adservicemedia.dk/cgi-bin/Services/ImpressionService/Image.pl"]
+mobiili.fi#?#a.isobrick.half.one_col > .featuredinner:-abp-has(.bubble:-abp-contains(Sponsoroitu))
+mobiili.fi#?#div.fullarticle:-abp-has(img[src="https://mobiili.fi/aaa.png"])
+mobiili.fi#?#p:-abp-has(small:-abp-contains(Mainos:))
 moottori.fi##.category-kumppaniartikkeli.moottori_kumppani.smallfeature
 moottori.fi##.kumppaniartikkeli-sidebar.smallfeature
 moottori.fi##div[class*="torifi_banner"]
-moottoripyora.org##LI[class="first cooperation nebula"]
 moottoripyora.org##a[href*="mst-yhtiot"]
+moottoripyora.org##LI[class="first cooperation nebula"]
 moottoripyora.org##li[id*="navbar_notice_"]
 motot.net##div.centered.motot-well-inverse.well[style^="padding-"]
+motouutiset.fi##a[href*="revads"]
 motouutiset.fi##DIV[class*="ad-giant"]
 motouutiset.fi##DIV[class*="ad-panorama"]
-motouutiset.fi##a[href*="revads"]
 mtvuutiset.fi##.component-adincontent.component
 mtvuutiset.fi##.leaderboard-1.leaderboard
+murha.info#?##custom_html-4 > .custom-html-widget.textwidget > table > tbody > tr > td
+murha.info#?#.widget_text.widget:-abp-contains(/Mainos|Autonosatkauppa.fi|Jurinet/)
 murobbs.muropaketti.com###hintaopas_top_product_block
+murobbs.muropaketti.com##a[href*="emediate"]
 murobbs.muropaketti.com##DIV[class="funboxWrapper"]
 murobbs.muropaketti.com##DIV[class="om-container"]
 murobbs.muropaketti.com##IFRAME[id="hintaopas_box"]
 murobbs.muropaketti.com##IFRAME[src="https://murobbs.muropaketti.com/aulis/muro-monster-feed.html"]
-murobbs.muropaketti.com##a[href*="emediate"]
 muropaketti.com##.hintavertailu--widget.hintavertailu
 muropaketti.com##SECTION[id*="hintaopaspopular"]
 muropaketti.com##SECTION[id*="yhteistyossa"]
+muropaketti.com#?#article.grid__item_md-1-5.grid__item_1:-abp-contains(Mainos)
 mvlehti.net##.ad
 mvlehti.net##.comments-container > .premium_container
 mvlehti.net##.entry-content > .premium_container
@@ -357,11 +405,11 @@ nainen.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoill
 nainen.com##[href="https://www.nainen.com/lainoja-kilpailuttamalla-saastat-aikaa-ja-rahaa/"]
 napsu.fi###banneriwrapper
 nettiauto.com,nettikaravaani.com,nettikone.com,nettimarkkina.com,nettimokki.com,nettimoto.com,nettivaraosa.com,nettivene.com###homeTopBoxBanner
+nettiauto.com,nettikaravaani.com,nettikone.com,nettimoto.com,nettivaraosa.com,nettivene##.listing
 nettiauto.com,nettikaravaani.com,nettikone.com,nettimoto.com,nettivaraosa.com,nettivene.com##.inh_banner_nl
 nettiauto.com,nettimoto.com###homeBottomBoxBanner
 nettiauto.com,nettimoto.com,nettivaraosa.com,nettimarkkina.com,nettikone.com##DIV[id="huge_banner"]
 nettiauto.com,nettimoto.com,nettivaraosa.com,nettimarkkina.com,nettikone.com##LI#left_part
-nettiauto.com,nettikaravaani.com,nettikone.com,nettimoto.com,nettivaraosa.com,nettivene##.listing
 nyt.fi##DIV#javascript-disabled-error
 offroadpro.fi,mpmaailma.fi##div[class*="advertisement"]
 offroadpro.fi,mpmaailma.fi##div[class*="bgBanner"]
@@ -422,17 +470,20 @@ sss.fi##[class="td_block_wrap td_block_instagram td_block_widget td_uid_24_5ed01
 suomela.fi##.banner-boksi1
 suomi24.fi##.editorial-slots
 suomi24.fi##div[class*="Ad__AdWrapper"]
+suomi24.fi#?#div[class^="ThreadGridItemWrapper__CardCol"]:-abp-has([class^="AdLivewrapped__AdWrapper"])
 suomifutis.com##[href$="/nettikasinot/"]
 superlehti.fi##.ad-banner-lift__article.ad-banner-lift
 supersaa.fi##div[class^="supers-app-promo-container"]
+taisto.org###mw-data-after-content > div
+taisto.org##a[id="top"] ~ [id="siteNotice"][class="mw-body-content"]
 talouselama.fi##[id="skyscraper-height-div"] > div > main > div[class="LazyLoad is-visible"] > section > div:first-of-type + div[class^="sc-"]
 talouselama.fi##div#skyscraper-height-div > aside > div > a[href^="/kumppaniblogit/"]
 talouselama.fi##div#skyscraper-height-div > div > aside > div > a[href^="/kumppaniblogit/"]
 talouselama.fi##div#skyscraper-height-div > div > aside > div > a[href^="https://studio.talouselama.fi/"] > div[class^="sc-"]
 talouselama.fi##div[class^="article-body"] > div[class^="sc-"]:not(:nth-last-child(2))
 talouselama.fi##div[id="skyscraper-height-div"] > div[class="LazyLoad is-visible"] > section > div:first-of-type + div[class^="sc-"]
-taisto.org###mw-data-after-content > div
-taisto.org##a[id="top"] ~ [id="siteNotice"][class="mw-body-content"]
+talouselama.fi#?#div#skyscraper-height-div > div > aside > div > div:-abp-contains(KAUPALLINEN YHTEISTYÖ)
+talouselama.fi#?#div#skyscraper-height-div > section > div > div:-abp-has([src*="assets.almatalent.fi/static/podcasts/te/Privanet/privanet-podcast.jpg"]):-abp-contains(Kaupallinen Yhteistyö)
 tehylehti.fi##.commercial-bottom.commercial
 tehylehti.fi##.commercial_wrapper
 tekniikanmaailma.fi##.in-text-ad-slot-wrapper
@@ -440,20 +491,29 @@ tekniikanmaailma.fi##.NoAdBlocker_main
 tekniikkatalous.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="/kumppaniblogit/"]
 tekniikkatalous.fi##div#skyscraper-height-div > div > aside > div > div > a[href^="https://studio.tekniikkatalous.fi/"]
 tekniikkatalous.fi##div#skyscraper-height-div > div > section > div > a[href^="/kumppaniblogit/"]
+tekniikkatalous.fi#?#div#skyscraper-height-div > aside > div > div > a:-abp-contains(Kaupallinen yhteistyö)
+tekniikkatalous.fi#?#div#skyscraper-height-div > section > div > a:-abp-contains(Kaupallinen yhteistyö)
 telsu.fi###pb_bottom2
 ticketmaster.fi##div[id^="ad-slot-"]
 tilt.fi##.lazyloading
 tivi.fi##a[href^="/kumppaniblogit/"]
 tivi.fi##a[href^="https://studio.tivi.fi/"][href*="studiovieras"]
+tivi.fi#?#div#skyscraper-height-div > aside > div > section > div:-abp-contains(KAUPALLINEN YHTEISTYÖ)
+tivi.fi#?#div#skyscraper-height-div > div > aside > div > section > div:-abp-contains(KAUPALLINEN YHTEISTYÖ)
+tivi.fi#?#div#skyscraper-height-div > div > section > div > div > aside:-abp-contains(KAUPALLINEN YHTEISTYÖ)
+tivi.fi#?#div#skyscraper-height-div > section > div > a > div:-abp-contains(Kaupallinen yhteistyö)
 tulikulma.fi##.slideshow
 uudenkaupunginsanomat.fi###auto-grid-container-5c40764673d19
+uusisuomi.fi#?#div#skyscraper-height-div > aside > section > a:-abp-contains(Kaupallinen yhteistyö)
+uusisuomi.fi#?#div#skyscraper-height-div > div > aside > section > a:-abp-contains(Kaupallinen yhteistyö)
+uusisuomi.fi#?#div#skyscraper-height-div > div > main > div > a:-abp-contains(Kaupallinen yhteistyö)
 uutissuora.fi##div[class="td-all-devices"]
 valioliiga.com##[href$="/vedonlyonti/"]
 vantaansanomat.fi##div.display-ad
 vapaasana.swedishforum.net###p0
 vapaavuoro.uusisuomi.fi##div[id="etuoviVVAdPrototype"]
-vauva.fi##div[id^="aldente-"]
 vauva.fi##div.cts-row-wrapper
+vauva.fi##div[id^="aldente-"]
 venelehti.fi###dfp__rectangle-1_1
 venelehti.fi##.ads_carousel-2.widget
 venelehti.fi##article[data-template-type="nativead"]
@@ -629,6 +689,15 @@ mtvuutiset.fi,mtv.fi,suomiareena.fi,www.studio55.fi,lumijapyry.fi,www.msn.com##.
 ! Adblock check
 murha.info#@#.adsbygoogle
 murha.info#@#.adsbox
+
+! ABP-only version of uBO/AdGuard-formatted "$redirect" entries
+!#if !ext_ublock
+!#if !adguard
+||damoh.katsomo.fi/*$media,rewrite=abp-resource:blank-mp3,domain=mtvuutiset.fi|mtv.fi|suomiareena.fi|www.studio55.fi|lumijapyry.fi|www.msn.com
+!#endif
+!#endif
+! appears when blocking ^^:
+||mobiili.fi/wp-content/themes/mobiilitheme/images/small-loading.gif$image
 
 ! -----UNSORTED END-----
 ! -----UNBREAK-----

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -1,79 +1,15 @@
 ! -----EXTENDED FILTERS-----
 
-aamulehti.fi##DIV[id*="pipe"] > div > div:has-text(Kaupallinen yhteistyö)
-aamulehti.fi##DIV[id^="morearticles_"]:has(h2:has(span:has-text(Kaupallinen yhteistyö)))
-arvopaperi.fi##div#skyscraper-height-div > aside > div > a:has-text(Kaupallinen yhteistyö)
-arvopaperi.fi##div#skyscraper-height-div > aside > div > div:has-text(Kaupallinen yhteistyö)
-arvopaperi.fi##div#skyscraper-height-div > div > aside > div > a:has-text(Kaupallinen yhteistyö)
-arvopaperi.fi##div#skyscraper-height-div > div > div > div > div > div > a:has-text(Kaupallinen yhteistyö)
 basso.fi###header-main:style(margin-top: 0px !important)
 basso.fi###header:style(min-height: auto !important)
 hardelli.com##a[class="td-post-category"][href="https://hardelli.com/category/pelit/"]:upward(3)
-hs.fi##.embedded:has-text(Markkinapaikka)
-hs.fi##article:has(a[href^="https://tilaa.sanoma.fi/hs-digi"])
-iltalehti.fi##.article-container:has-text(Kaupallinen yhteistyö)
-iltalehti.fi##.card:has(.block > a[class="nakoislehti"][href^="https://plus.iltalehti.fi/nakoislehti/"])
-iltalehti.fi##.card:has(.full-article:has-text(Kaupallinen yhteistyö))
-iltalehti.fi##.card:has(.half-article:has-text(Kaupallinen yhteistyö)):not(:has(.half-article:not(:has-text(Kaupallinen yhteistyö))))
-iltalehti.fi##.card:has-text(kaupallinen yhteistyö)
-iltalehti.fi##.half-article:has-text(Kaupallinen yhteistyö)
-iltalehti.fi##a.small-article:has-text(Kaupallinen yhteistyö)
-iltalehti.fi##div.fp-container.card:has([href*="clark-taloutesi-tukena"])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/Nauha_Rantapallo"])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/asuminen_vattenfall_palkki"])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/kuvat/nauhat/ky_" i])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/kuvat/nauhat/nauha_ky_" i])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/kuvat/nauhat/nauha_terveys_specsavers"])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/ky-" i])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/ky_" i])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/*mainosnauha" i])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/mainosnauhta"])
-iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/*kaupallinenyht*" i])
-iltalehti.fi##div.fp-container.card:has-text(Kaupallinen yhteistyö)
-iltalehti.fi##div.is-visible.LazyLoad:has-text(kaupallinen yhteistyö)
-inssinosingot.fi##div[class="row align-center"]:has([class$="lazy-load-active"])
-io-tech.fi##div.artikkeli-slide:has([src*="-nosto"])
-io-tech.fi##div.artikkeli-slide:has([src*="samsung-ssd8-10-240x160_center_center.jpg"])
 kaleva.fi##div[class^="m-contentListItem__advertisement"]:upward(4)
 kaleva.fi##span[class^="m-contentListItemThumb__advertisementLabel"]:upward(4)
-kauppalehti.fi##div#skyscraper-height-div > aside > aside > section > a:has-text(Kaupallinen yhteistyö)
-kauppalehti.fi##div#skyscraper-height-div > aside > section > a:has-text(Kaupallinen yhteistyö)
-kauppalehti.fi##div#skyscraper-height-div > div > aside > aside > section > a:has-text(Kaupallinen yhteistyö)
-kauppalehti.fi##div#skyscraper-height-div > div > main > a:has-text(Kaupallinen yhteistyö)
-kauppalehti.fi##div#skyscraper-height-div > main > aside > div > a:has-text(Kaupallinen yhteistyö)
-laliiga.com,leijonat.com,nhlsuomi.com,suomifutis.com,suomikiekko.com,valioliiga.com##.td-post-content > h4:has-text(talletusbonus)
-laliiga.com,leijonat.com,nhlsuomi.com,suomifutis.com,suomikiekko.com,valioliiga.com##.td-post-content > ol:has-text(pelitili)
 lapinkansa.fi##[class="m-contentListItemThumb__advertisement -medium -ctx-frontpage-now -level-1"]:upward(3)
 lapinkansa.fi##[class="m-contentListItem__advertisement -ctx-index -medium -level-1"]:upward(4)
 lbaanijakuva.fi##.background-ad:style(min-height: 0 !important;)
-marmai.fi##div#skyscraper-height-div > aside > a[href^="https://studio.marmai.fi/"]:has-text(Kaupallinen yhteistyö)
-marmai.fi##div#skyscraper-height-div > div > aside > a[href^="https://studio.marmai.fi/"]:has-text(Kaupallinen yhteistyö)
-marmai.fi##div#skyscraper-height-div > div > section > div > div > div:has-text(Kaupallinen yhteistyö)
-! Bad rule, don't add, can remove legit articles. Just as a reminder...
-! mediuutiset.fi##div#skyscraper-height-div > div:has-text(Kaupallinen Yhteistyö)
-mediuutiset.fi##div#root > div > div > div > div > div > div:has-text(Kaupallinen Yhteistyö)
-mobiili.fi##a.isobrick.half.one_col > .featuredinner:has(.bubble:has-text(Sponsoroitu))
-mobiili.fi##div.fullarticle:has(img[src="https://mobiili.fi/aaa.png"])
-mobiili.fi##p:has(small:has-text(Mainos:))
-murha.info##.widget_text.widget:has-text(/Mainos|Autonosatkauppa.fi|Jurinet/)
-murha.info###custom_html-4 > .custom-html-widget.textwidget > table > tbody > tr > td
-muropaketti.com##article.grid__item_md-1-5.grid__item_1:has-text(Mainos)
 shakerlehti.fi##a[href="/artikkelit/kaupallinen-yhteistyo/"]:upward(3)
-suomi24.fi##div[class^="ThreadGridItemWrapper__CardCol"]:has([class^="AdLivewrapped__AdWrapper"])
-talouselama.fi##div#skyscraper-height-div > div > aside > div > div:has-text(KAUPALLINEN YHTEISTYÖ)
-talouselama.fi##div#skyscraper-height-div > section > div > div:has([src*="assets.almatalent.fi/static/podcasts/te/Privanet/privanet-podcast.jpg"]):has-text(Kaupallinen Yhteistyö)
-tekniikkatalous.fi##div#skyscraper-height-div > aside > div > div > a:has-text(Kaupallinen yhteistyö)
-tekniikkatalous.fi##div#skyscraper-height-div > section > div > a:has-text(Kaupallinen yhteistyö)
-! Bad rule, don't add, can remove legit blogs. Just as a reminder...
-! tivi.fi##div#skyscraper-height-div > div > section > div:has-text(Kaupallinen yhteistyö)
 tivi.fi##:xpath(//h2[contains(text(),"Kaupallinen yhteistyö")]/../..)
-tivi.fi##div#skyscraper-height-div > aside > div > section > div:has-text(KAUPALLINEN YHTEISTYÖ)
-tivi.fi##div#skyscraper-height-div > div > aside > div > section > div:has-text(KAUPALLINEN YHTEISTYÖ)
-tivi.fi##div#skyscraper-height-div > div > section > div > div > aside:has-text(KAUPALLINEN YHTEISTYÖ)
-tivi.fi##div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
-uusisuomi.fi##div#skyscraper-height-div > aside > section > a:has-text(Kaupallinen yhteistyö)
-uusisuomi.fi##div#skyscraper-height-div > div > aside > section > a:has-text(Kaupallinen yhteistyö)
-uusisuomi.fi##div#skyscraper-height-div > div > main > div > a:has-text(Kaupallinen yhteistyö)
 vapaasana.swedishforum.net###main-content:style(margin-top: -100px !important;)
 www.ts.fi##div[class$="nativead"]:upward(6)
 
@@ -81,8 +17,6 @@ www.ts.fi##div[class$="nativead"]:upward(6)
 ! -----NETWORK FILTERS-----
 
 ||damoh.katsomo.fi/*$media,redirect=noop-0.1s.mp3,domain=mtvuutiset.fi|mtv.fi|suomiareena.fi|www.studio55.fi|lumijapyry.fi|www.msn.com
-! appears when blocking ^^:
-||mobiili.fi/wp-content/themes/mobiilitheme/images/small-loading.gif$image
 
 ! -----NETWORK FILTERS END-----
 ! -----SCRIPTS-----
@@ -103,4 +37,4 @@ proxyproxy.fi,pirateproxy.fi##+js(nowoif)
 
 uusisuomi.fi,xxl.fi,kaleva.fi##+js(acis, NREUM)
 
-! -----SCRIPTS END-----
+! -----SCRIPTS END----


### PR DESCRIPTION
Yes, I know what you're thinking. Why doesn't ABP simply add support for ":has" and ":has-text", instead of creating completely new syntaxes of their own despite an existing naming precedent for them? Well, Adblock Plus' coding team was a mysterious place and entity, especially before they opened up a GitLab issue tracker last winter (and sometimes even then).

To the best of my knowledge, all major adblockers support ":-abp-has" and ":-abp-contains", even if uBO only seems to do it out of necessity. So here's my entry conversion that will (hopefully) make for a good bid for getting this list into ABP, presuming that #251 came to an inconclusive standstill to the extent where the matter of ABP inclusion could be restarted a bit.

Note: It is technically also possible to convert e.g. `.element:upward(3)` into `*:-abp-has(> * > * > .element)`, but I figured I shouldn't place too much odd conversion possibilities on your shoulders for now.