### PR TITLE
Filter to remove the "caid" param from Freewheel requests

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,5 +1,5 @@
 [Adblock Plus 3.13]
-! Version: 26February2023v1
+! Version: 11March2023v4
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
 ! Expires: 4 days

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1,5 +1,5 @@
 [Adblock Plus 3.13]
-! Version: 19February2023v1
+! Version: 26February2023v1
 ! Title: Adblock List for Finland
 ! Description: Finnish adblock list
 ! Expires: 4 days

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -87,3 +87,6 @@ iltalehti.fi#?#.double-column > a[href]:-abp-has(.article-container:has-text(Kau
 ! https://github.com/easylist/easylist/pull/8317
 pelaaja.fi##+js(aopr, ga)
 ||pelaaja.fi/sites/default/files/googleanalytics/analytics.js$important
+
+! Removes the caid parameter from Freewheel requests to clean up Sanoma websites from video/audio ads
+||7caa2.v.fwmrm.net/ad/g/1$removeparam=caid

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -66,6 +66,7 @@ tamperelainen.fi##^.display-ad
 
 ||doubleclick.net^$xmlhttprequest,redirect=nooptext,domain=puhekupla.com
 ||elisa.digital.nuance.com/tagserver/js/ads-blocking-detector.min.js$domain=elisa.fi
+||v.fwmrm.net/ad/g/1$removeparam=caid
 ||telsu.fi/x_abcheck$xhr,domain=telsu.fi
 
 ! -----NETWORK FILTERS END-----
@@ -87,6 +88,3 @@ iltalehti.fi#?#.double-column > a[href]:-abp-has(.article-container:has-text(Kau
 ! https://github.com/easylist/easylist/pull/8317
 pelaaja.fi##+js(aopr, ga)
 ||pelaaja.fi/sites/default/files/googleanalytics/analytics.js$important
-
-! Removes the caid parameter from Freewheel requests to clean up Sanoma websites from video/audio ads
-||7caa2.v.fwmrm.net/ad/g/1$removeparam=caid


### PR DESCRIPTION
Added a filter to remove the "caid" parameter from Freewheel requests to clean up Sanoma websites from video/audio ads.
I tested this filter on [Supla](https://supla.fi), [Helsingin Sanomat](https://hs.fi/kaupunki/espoo/art-2000009385057.html), and [Ilta-Sanomat](https://www.is.fi/viihde/art-2000009418765.html). I didn't test on [Ruutu](https://ruutu.fi) as it requires an account. If someone could test it for me that would be great.
Unlike blocking the Freewheel requests (7caa2.v.fwmrm.net/ad/g/1) or redirecting them to noop resources, removing the "caid" param doesn't trip the adblock detection.

Currently the ad blocking operates based on redirecting the video/audio files of the ads to noop resources, but that way of blocking has side effects. For example, Supla shows briefly "Mainos 1/4" etc. Pausing on Supla also sometimes, on Firefox for Android, breaks because of the current way of blocking ads. By removing the "caid" param, the Freewheel server returns a response which doesn't contain any references to the ads, so the client does not attempt to play any ads.

I also didn't remove the block rules blocking the servers hosting the ads, as this fix only works with uBO (and maybe AdGuard).
I intentionally only blocked the domain for Sanoma, as I don't know how other services behave with this fix.