### PR TITLE
Text ads on fillaritori.com

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -328,9 +328,8 @@ fel.gg###fel-ad-banner
 fiksukuluttaja.fi##.thirstylinkimg
 fiksukuluttaja.fi,lehtikeidas.fi##[href^="https://online.adservicemedia.dk/cgi-bin/click.pl"]
 fillarifoorumi.fi###ad_global_below_navbar
-fillaritori.com###fillaritori_mobileheader
+fillaritori.com##[data-nbenhadv]
 fillaritori.com###ipsLayout_mainArea > center
-fillaritori.com##.ipsLayout_sidebarright
 findance.com##div[id^=adslot_content]
 findance.com##div[id^=adslot_sidebar]
 findance.com#?#p:-abp-has(> [rel=sponsored])

--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -330,6 +330,7 @@ fiksukuluttaja.fi,lehtikeidas.fi##[href^="https://online.adservicemedia.dk/cgi-b
 fillarifoorumi.fi###ad_global_below_navbar
 fillaritori.com##[data-nbenhadv]
 fillaritori.com###ipsLayout_mainArea > center
+fillaritori.com##.ipsLayout_sidebarright
 findance.com##div[id^=adslot_content]
 findance.com##div[id^=adslot_sidebar]
 findance.com#?#p:-abp-has(> [rel=sponsored])


### PR DESCRIPTION
Added a filter which covers all ads on fillaritori.com.
The `#ipsLayout_mainArea > center` filter was left since it gets rid of the extra space on the top of the page.
Performance seems similar to the previous filters.