### PR TITLE
Ads on `https://www.s-kaupat.fi`

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -178,7 +178,7 @@ alypaa.com,pelikone.fi##.text-link[href*="&utm_medium=banner&utm_campaign="]
 alypaa.com,pelikone.fi##.text-link[href^="https://clk.tradedoubler.com/"]
 ampparit.com##.mobile-leaderboard-container
 ampparit.com##.resize-container
-ampparit.com,kirkkojakaupunki.fi,kuntalehti.fi,luukku.com,mtvuutiset.fi,seiska.fi,styleroom.fi,viinilehti.fi##.ad-container
+ampparit.com,keskustelu.suomi24.fi,kirkkojakaupunki.fi,kuntalehti.fi,luukku.com,mtvuutiset.fi,seiska.fi,styleroom.fi,viinilehti.fi##.ad-container
 anna.fi#?#.grid__item_1:-abp-has(> [id^=dfp__native-card])
 anna.fi#?#li:-abp-has([id^=dfp__native-card])
 anna.fi,kaksplus.fi##.widget_nativearticles
@@ -975,7 +975,7 @@ suomifutis.com#?#.menu-item:-abp-has([href*="/veikkausvihjeet"])
 suomikiekko.com#?#.menu-item:-abp-has([href$="/pitkavetovihjeet/"])
 suomimobiili.fi##.artikkelimainos
 suomimobiili.fi##.headermainos
-suomimobiili.fi#?#.article-content > p:has-text(MAINOS)
+suomimobiili.fi##.natiivilinkit
 suomimobiili.fi#?#.posts-list > .list-item:-abp-has([href="https://suomimobiili.fi/kategoria/sponsoroitu/"])
 suomimobiili.fi#?#.posts-listing-list-alt-b:has-text(Artikkeleita kumppaneilta)
 superlehti.fi##.ad-banner-lift
@@ -1271,6 +1271,7 @@ _300x300_*.mp4$media,domain=futisfani.com|kiekkofani.com|penkkiurheilu.com|uutis
 ||carousel-prod-kaleva-fi.s3.amazonaws.com^$third-party
 ||cdn.bluebillywig.com/apps/player/$script,domain=gekkonen.net|hevosurheilu.fi
 ||celtra.com^$third-party
+||cfapi.voikukka.fi/graphql?operationName=CitrusAd&$xmlhttprequest,domain=s-kaupat.fi
 ||cjar.a-lehdet.fi^$third-party
 ||cloudfront.net/images/backgroundimages/backgroundimage^$third-party
 ||cloudfront.net/poppartners/$script

--- a/Finland_adb_uBO_extras.txt
+++ b/Finland_adb_uBO_extras.txt
@@ -16,6 +16,7 @@ golfpiste.com#?#.section-wrapper > .has-ad-right:-abp-has(+ .section--ad:matches
 hardware.fi##.top-ad-space:style(min-height: 0 !important)
 hardware.fi#@#.top-ad-space
 ilkkapohjalainen.fi##.site__wrapper:style(margin-top: 0.5em !important)
+iltalehti.fi#?#.double-column > a[href]:-abp-has(.article-container:has-text(Kaupallinen yhteistyö)):remove()
 kaaoszine.fi##article.post:has-text(Kaupallinen yhteistyö):style(height: 1px !important; width: 1px !important; margin-right: 0px !important)
 kaaoszine.fi#@#article.post:has-text(Kaupallinen yhteistyö)
 kaksplus.fi##body.home #section-0 article:nth-child(1), body.category #om_commercialpostlisting-1 article:nth-child(1):style(margin-bottom: unset !important;)
@@ -78,7 +79,7 @@ finder.fi##+js(rc, SearchResultList--advertisement, , stay)
 finder.fi##+js(rc, SearchResultList__Row--advertisement, , stay)
 findit.fi##+js(acs, testPrebid)
 happypancake.fi##+js(aopr, Object.prototype.adUnits)
-iltalehti.fi#?#.double-column > a[href]:-abp-has(.article-container:has-text(Kaupallinen yhteistyö)):remove()
+s-kaupat.fi##+js(json-prune, props.pageProps.contentfulState.frontPage.sections.[].fields.hasCitrusAdSlot)
 
 ! -----SCRIPTS END-----
 


### PR DESCRIPTION
Extra:
Add back .ad-container filter for keskustelu.suomi24.fi (ads on search pages)
Optimize a filter for suomimobiili.fi (from procedural to a simple class filter)
Move a filter for iltalehti.fi (uBO-specific) from scripts section to specific filters