### PR TITLE
Ran PyFunceble

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1280,7 +1280,6 @@ _300x300_*.mp4$media,domain=futisfani.com|kiekkofani.com|penkkiurheilu.com|uutis
 ||cloudfront.net/poppartners/$script
 ||deals.innocode.no/api/public/v1/widgets$domain=aland.com|alandstidningen.ax|enontekionsanomat.fi|inarilainen.fi|kainuunsanomat.fi|kittilalehti.fi|kotilappi.fi|kuhmolainen.fi|luoteis-lappi.fi|saariselansanomat.fi|sompio.fi|sotkamolehti.fi|ylakainuu.fi
 ||deals.kledjut.com^$domain=viranomaisuutiset.fi
-||dni-adops-proxy-prod-adopsmediaconverter.mercury.dnitv.com^$media,domain=discoveryplus.fi
 ||elmotv.com/wp-content/uploads/*/stake-banneri-$image,domain=elmotv.com
 ||es.ylilauta.org^$domain=ylilauta.org
 ||etn.fi/images/banners/$image


### PR DESCRIPTION
Among relevant entries, it appears that only this one was viable for removal, seeing as Discovery+ have moved almost entirely to `.com` nowadays.