### PR TITLE
Attempting to apply ABP's new syntax guidelines

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -117,7 +117,7 @@ _mainosnappi.
 ! -----SPECIFIC FILTERS-----
 
 2pos.life##.ad2
-aamulehti.fi#?#article[class]:has(> a[href^="https://tilaa.sanoma.fi/al-digi"][href$=etusivu_flash])
+aamulehti.fi##article[class]:has(> a[href^="https://tilaa.sanoma.fi/al-digi"][href$=etusivu_flash])
 aamulehti.fi,hs.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,suurkeuruu.fi,sydansatakunta.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi##.teaser-ad__background
 aamulehti.fi,hs.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,suurkeuruu.fi,sydansatakunta.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi##div[class] > a[href^="https://tilaa.sanoma.fi/"]
 aamulehti.fi,hs.fi,jamsanseutu.fi,janakkalansanomat.fi,kankaanpaanseutu.fi,kmvlehti.fi,merikarvialehti.fi,nokianuutiset.fi,rannikkoseutu.fi,satakunnankansa.fi,suurkeuruu.fi,sydansatakunta.fi,tyrvaansanomat.fi,valkeakoskensanomat.fi##.ticker--promo-10
@@ -132,7 +132,7 @@ aijaa.com##div.text-center.col-sm-6 > a[rel$=nofollow]
 aitiydenihme.fi,askelterveyteen.com,mielenihmeet.fi,myanimals.com##.bc--grey-neutral-50
 aitiydenihme.fi,askelterveyteen.com,mielenihmeet.fi,myanimals.com##.card-article-ads
 akaanseutu.fi,lvs.fi,orivedensanomat.fi,pirkkalainen.fi,shl.fi##.teivo-sidebar
-akaanseutu.fi,lvs.fi,orivedensanomat.fi,pirkkalainen.fi,shl.fi,ylojarvenuutiset.fi#?#.feedraviraportit:has(.mainosfeedravi)
+akaanseutu.fi,lvs.fi,orivedensanomat.fi,pirkkalainen.fi,shl.fi,ylojarvenuutiset.fi##.feedraviraportit:has(.mainosfeedravi)
 akaanseutu.fi,lvs.fi,shl.fi,ylojarvenuutiset.fi##[href="/tilaa-lehti"]
 aksa.fi##.vaihtuvamainos
 aksa.fi##div[class="w-full md:w-2/5 pt-6 md:pt-0 pl-0 md:pl-8"]
@@ -149,14 +149,14 @@ alandstidningen.ax###block-views-block-bilwebben-block-1
 alandstidningen.ax###block-views-block-company-ads-block-1
 alandstidningen.ax##.editorial-ad
 alandstidningen.ax##div[id|=block-googleadmaincontent]
-alandstidningen.ax#?#.views-element-container:has(a[href^="https://www.marknaden.ax/annons"])
+alandstidningen.ax##.views-element-container:has(a[href^="https://www.marknaden.ax/annons"])
 alandstidningen.ax#?#.views-element-container:has-text(Annonsnytt)
 alfatvuutiset.fi##.ugaam-archive-ad-wrapper
 alfatvuutiset.fi#?#.widget_text:has-text(Advertisement)
 alibi.fi##.box--full.grid__container.clearfix
 alibi.fi##.magazineorderwidget__content
 alibi.fi#?#.article__body > p:has-text(/^\xA0$/)
-alibi.fi#?#.sidebar-block:has(img.awpo-lazy)
+alibi.fi##.sidebar-block:has(img.awpo-lazy)
 alibi.fi,ampparit.com,anna.fi,eralehti.fi,golfpiste.com,hymy.fi,kaksplus.fi,kipparilehti.fi,kotiliesi.fi,koululainen.fi,muropaketti.com,nettiauto.com,nettikaravaani.com,nettikone.com,nettimokki.com,nettimoto.com,nettivaraosa.com,nettivene.com,nettivuokraus.com,rakennusmaailma.fi,seura.fi,suomenkuvalehti.fi,tekniikanmaailma.fi,venelehti.fi##div[id^=dfp__]
 alibi.fi,hymy.fi##.sidebar-block > a[href^="http://pubads.g.doubleclick.net/gampad/clk"]
 alibi.fi,hymy.fi##[href*="paratiisi.fi"]
@@ -167,41 +167,41 @@ alueviesti.fi##.widget.sima
 alypaa.com##.ad.right-col-box
 alypaa.com##.banner-slot-box
 alypaa.com##[class^=banner-slot-preroll]
-alypaa.com#?#.section-inner:has(> .banner-slot)
-alypaa.com#?#.section-inner:has(> div[style] > .sanoma-ad-banner)
+alypaa.com##.section-inner:has(> .banner-slot)
+alypaa.com##.section-inner:has(> div[style] > .sanoma-ad-banner)
 alypaa.com,pelikone.fi##.text-link[href*="&utm_medium=banner&utm_campaign="]
 alypaa.com,pelikone.fi##.text-link[href^="https://clk.tradedoubler.com/"]
 ampparit.com##.mobile-leaderboard-container
 ampparit.com##.resize-container
 ampparit.com,keskustelu.suomi24.fi,kirkkojakaupunki.fi,kuntalehti.fi,luukku.com,mtvuutiset.fi,seiska.fi,styleroom.fi,viinilehti.fi##.ad-container
 animelehti.fi,como.fi,episodi.fi,fum.fi,inferno.fi,leffatykki.com,pelaaja.fi,pelaajat.com,rumba.fi,soundi.fi,tilt.fi##.strossle > div[class*=post-ad]
-animelehti.fi,episodi.fi,inferno.fi#?#.px-4.py-2.bg-white.w-full:has(.poppartners)
+animelehti.fi,episodi.fi,inferno.fi##.px-4.py-2.bg-white.w-full:has(.poppartners)
 animelehti.fi,episodi.fi,inferno.fi,rumba.fi,soundi.fi,tilt.fi###tilt-ad-top-stay-away
-animelehti.fi,episodi.fi,inferno.fi,rumba.fi,tilt.fi#?#.px-4.py-2.bg-white.w-full:has([data-ad-unit-id])
-anna.fi#?#.grid__item_1:has(> [id^=dfp__native-card])
-anna.fi#?#li:has([id^=dfp__native-card])
+animelehti.fi,episodi.fi,inferno.fi,rumba.fi,tilt.fi##.px-4.py-2.bg-white.w-full:has([data-ad-unit-id])
+anna.fi##.grid__item_1:has(> [id^=dfp__native-card])
+anna.fi##li:has([id^=dfp__native-card])
 anna.fi,kaksplus.fi##.widget_nativearticles
 anna.fi,kotiliesi.fi###huomiotekstilinkki[href^="https://tilaus."]
 app.mtvuutiset.fi##.ppas
 app.mtvuutiset.fi##div[data-testid="endorsement"]
-app.mtvuutiset.fi#?#section > ul > li > div:has(a[data-testid="ad-article-teaser-tag"])
+app.mtvuutiset.fi##section > ul > li > div:has(a[data-testid="ad-article-teaser-tag"])
 apteekkari.fi##.frontpage-banner
 apteekkari.fi##.native-comms
 apteekkari.fi#?#.container:has-text(MAINOS (TEKSTI JATKUU ALLA))
-apu.fi#?#div[class*="PageBlock__ContentContainer"]:has(div[class*="ContentSpotlightBlock__AdLabel"])
+apu.fi##div[class*="PageBlock__ContentContainer"]:has(div[class*="ContentSpotlightBlock__AdLabel"])
 apu.fi,eeva.fi,lily.fi,meillakotona.fi,terve.fi##[class*=ad__component]
 apu.fi,eeva.fi,lily.fi,meillakotona.fi,terve.fi##[class^=Ad__AdRoot]
-apu.fi,meillakotona.fi#?#ul[class*="relatedContent__list"] > li:has([class*=ContentCard__AdLabel])
+apu.fi,meillakotona.fi##ul[class*="relatedContent__list"] > li:has([class*=ContentCard__AdLabel])
 arcticinsider.com##a[href*=bannerTrack]
 arvokisat.com,eurheilu.org,herkkusuut.com,huuhkajat.com,laliiga.com,leijonat.com,metropoli.net,nainen.com,nhlsuomi.com,sketsi.net,suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com,susijengi.com,tinderinparhaat.com,valioliiga.com,viikonloppu.com###outstream
 arvokisat.com,eurheilu.org,herkkusuut.com,huuhkajat.com,laliiga.com,leijonat.com,metropoli.net,nainen.com,nhlsuomi.com,sketsi.net,suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com,susijengi.com,tinderinparhaat.com,valioliiga.com,viikonloppu.com##.pnad-container
 arvokisat.com,eurheilu.org,herkkusuut.com,laliiga.com,leijonat.com,nainen.com,nhlsuomi.com,sketsi.net,suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com,susijengi.com,valioliiga.com,viikonloppu.com##.td-post-content > .social-share ~ *
-arvokisat.com,eurheilu.org,herkkusuut.com,laliiga.com,leijonat.com,nainen.com,nhlsuomi.com,sketsi.net,suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com,susijengi.com,valioliiga.com,viikonloppu.com#?#body.post-template-default * .td-main-content-wrap:has(.tdt-ad-wrap)
+arvokisat.com,eurheilu.org,herkkusuut.com,laliiga.com,leijonat.com,nainen.com,nhlsuomi.com,sketsi.net,suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com,susijengi.com,valioliiga.com,viikonloppu.com##body.post-template-default * .td-main-content-wrap:has(.tdt-ad-wrap)
 arvopaperi.fi##.ads-parade-wrapper
 arvopaperi.fi##a[href^="https://www.arvopaperi.fi/kumppanisisallot/"][target="_self"]:not(section > a)
-arvopaperi.fi#?#div#skyscraper-height-div > aside > div:has(a[href^="https://www.arvopaperi.fi/kumppanisisallot/"])
+arvopaperi.fi##div#skyscraper-height-div > aside > div:has(a[href^="https://www.arvopaperi.fi/kumppanisisallot/"])
 arvopaperi.fi,uusisuomi.fi#?#[width]:has(.lazyload-wrapper):not(aside)
-assembly.org#?#div[class] + div[class] ~ div[class]:has(> .lazyload-wrapper [data-adfscript])
+assembly.org##div[class] + div[class] ~ div[class]:has(> .lazyload-wrapper [data-adfscript])
 assembly.org#?#section:not(section[id], section[class]):has-text(Mainos)
 asunnot.oikotie.fi##.building-campaign-element
 asunnot.oikotie.fi##[analytics-impression="energy-promotion_listing-page_impression"]
@@ -211,7 +211,7 @@ asunnot.oikotie.fi##energy-promotion-building
 audiovideo.fi##.head.the-wrap
 audiovideo.fi##[id|=bunyad-widget-ads]
 auto1.fi##.pb[lazied]
-auto1.fi#?#[id^=pb_cont].pb:has(> a[href^="/clk2?"])
+auto1.fi##[id^=pb_cont].pb:has(> a[href^="/clk2?"])
 auto1.fi,ilmainensanakirja.fi,testeri.fi###pb_bottom
 auto1.fi,ilmainensanakirja.fi,testeri.fi##.box_dt
 auto1.fi,ilmainensanakirja.fi,testeri.fi##[href^="/clk"]
@@ -224,15 +224,15 @@ autotalli.com###topBanner
 avainlehti.fi##.teaser--ad
 avecmedia.fi##.front-page-ad-padding
 avecmedia.fi##.front-page-advertisement
-avplus.fi#?#.widget:has(.widget_advads_ad_widget)
+avplus.fi##.widget:has(.widget_advads_ad_widget)
 bbs.io-tech.fi##.structItem--thread[data-author=Mainos]
 bbs.io-tech.fi#?#div.node-extra:has-text(Mainos)
 bbs.io-tech.fi#?#li.block-row:has-text(Mainos)
 bittiraha.fi###cm-banner
-blogbook.fi#?#.sidebar-block:has([id^="adsivupalkki_"])
+blogbook.fi##.sidebar-block:has([id^="adsivupalkki_"])
 bomber.fi###rt-sidebar-b
 boy.fi##.advs
-boy.fi#?#.moduletable:has(.advs)
+boy.fi##.moduletable:has(.advs)
 brbikers.com##a[href*="tema.fi"]
 caravan-lehti.fi##.ad-wrapper
 caravan-lehti.fi##.widget_caravanlehti-ad
@@ -242,12 +242,12 @@ chat.suomi24.fi##.bannerTop.S24_banner
 como.fi##div[class="flex flex-wrap md:flex-nowrap lg:flex-nowrap gap-x-4"][style="min-height:500px;"]
 como.fi,episodi.fi,fum.fi,inferno.fi,pelaaja.fi,rumba.fi,soundi.fi##.poppartners
 como.fi,episodi.fi,fum.fi,inferno.fi,rumba.fi,soundi.fi,tilt.fi##div[data-recommendation-type=ad]
-como.fi,episodi.fi,fum.fi,inferno.fi,rumba.fi,soundi.fi,tilt.fi#?#.border-bottom.row:has(.poppartners)
+como.fi,episodi.fi,fum.fi,inferno.fi,rumba.fi,soundi.fi,tilt.fi##.border-bottom.row:has(.poppartners)
 como.fi,episodi.fi,inferno.fi,leffatykki.com,pelaaja.fi,rumba.fi,tilt.fi##.md\:bg-gray-200.md\:max-w-full.md\:px-4.md\:py-4
 como.fi,episodi.fi,rumba.fi,soundi.fi,tilt.fi##div.min-h-\[450px\]
 como.fi,pelaaja.fi##.px-4.py-2.border-b.border-gray-200.bg-white.w-full
 como.fi,rumba.fi,soundi.fi,tilt.fi##div[style="min-height:450px;"]
-como.fi,tilt.fi#?#div[class="w-full bg-white border-gray-200 border-b py-2 px-4"]:has([id*="_smart_boksi"])
+como.fi,tilt.fi##div[class="w-full bg-white border-gray-200 border-b py-2 px-4"]:has([id*="_smart_boksi"])
 como.fi,tilt.fi,rumba.fi#?#body:not(.post-type-archive-advertoriaali) .bg-white.p-3.mb-6:has(a[href*=".fi/advertoriaali/"])
 dailyfinland.fi##.wrepper.mx-auto > .row[style="margin-bottom:20px"]
 deitti.net##.ad-article
@@ -263,11 +263,11 @@ edgeski.fi,foregolf.fi,kalamies.com,rodeosnow.fi##.adv_content
 edgeski.fi,foregolf.fi,kalamies.com,rodeosnow.fi##.adv_side
 edgeski.fi,foregolf.fi,rodeosnow.fi##[id|=adni_widgets]
 edukas.fi##.compareGoogleCell
-eeva.fi#?#.swiper-slide:has(div[class*="ContentCard__AdLabel"])
+eeva.fi##.swiper-slide:has(div[class*="ContentCard__AdLabel"])
 eeva.fi#?#a[class^="ContentCard__Card-"]:has-text(Mainos: )
-eeva.fi#?#div[class^="ContentFlowBlock__CardContainer"]:has(div[class*="ContentCard__AdLabel"])
+eeva.fi##div[class^="ContentFlowBlock__CardContainer"]:has(div[class*="ContentCard__AdLabel"])
 eeva.fi#?#div[class^="EmbeddedArticle__Container"]:has(.category:has-text(Mainos:))
-eeva.fi#?#div[class^="EmbeddedArticle__Container"]:has(div[class*="CommercialLabelContainer"])
+eeva.fi##div[class^="EmbeddedArticle__Container"]:has(div[class*="CommercialLabelContainer"])
 eeva.fi#?#div[class^="StripeBannerBlock__StripeBannerContainer"]:has-text(Mainos:)
 ehandel.fi###div-leeadsFullpageAd
 ehandel.fi##.article-ad-container
@@ -288,10 +288,10 @@ elmotv.com##p img.alignnone[src$=".png"][alt=""][width="2560"][height^="20"]
 elmotv.com#?#.luelisaa > .solu:has-text(Kaupallinen yhteistyö)
 elmotv.com#?#[href]:has-text(LeoVegas)
 enontekionsanomat.fi,haapavesi-lehti.fi,inarilainen.fi,kainuunsanomat.fi,kalajokilaakso.fi,kalajokiseutu.fi,keskipohjanmaa.fi,kittilalehti.fi,kotikulmilta.fi,kotilappi.fi,kuhmolainen.fi,kuusamonseutu.fi,lestijoki.fi,luoteis-lappi.fi,meantornionlaakso.fi,nivala-lehti.fi,perhonjokilaakso.fi,pietarsaarensanomat.fi,saariselansanomat.fi,selanne-lehti.fi,sompio.fi,sotkamolehti.fi,ylakainuu.fi##div[id^=article-ad]
-enontekionsanomat.fi,haapavesi-lehti.fi,inarilainen.fi,kainuunsanomat.fi,kalajokilaakso.fi,kalajokiseutu.fi,keskipohjanmaa.fi,kittilalehti.fi,kotikulmilta.fi,kotilappi.fi,kuhmolainen.fi,kuusamonseutu.fi,lestijoki.fi,luoteis-lappi.fi,meantornionlaakso.fi,nivala-lehti.fi,perhonjokilaakso.fi,pietarsaarensanomat.fi,saariselansanomat.fi,selanne-lehti.fi,sompio.fi,sotkamolehti.fi,ylakainuu.fi#?#.widget_text:has([data-ad-unit-id])
+enontekionsanomat.fi,haapavesi-lehti.fi,inarilainen.fi,kainuunsanomat.fi,kalajokilaakso.fi,kalajokiseutu.fi,keskipohjanmaa.fi,kittilalehti.fi,kotikulmilta.fi,kotilappi.fi,kuhmolainen.fi,kuusamonseutu.fi,lestijoki.fi,luoteis-lappi.fi,meantornionlaakso.fi,nivala-lehti.fi,perhonjokilaakso.fi,pietarsaarensanomat.fi,saariselansanomat.fi,selanne-lehti.fi,sompio.fi,sotkamolehti.fi,ylakainuu.fi##.widget_text:has([data-ad-unit-id])
 enontekionsanomat.fi,inarilainen.fi,kainuunsanomat.fi,kittilalehti.fi,kotilappi.fi,kuhmolainen.fi,luoteis-lappi.fi,saariselansanomat.fi,sompio.fi,sotkamolehti.fi,ylakainuu.fi##.dls-loaded
 epari.fi,ilkkapohjalainen.fi,jarviseutu-lehti.fi,jurvansanomat.fi,komiat.fi,suupohjansanomat.fi,vaasalehti.fi,viiskunta.fi#?#article > div[class]:has-text(Mainos (sisältö jatkuu alla))
-epari.fi,ilkkapohjalainen.fi,jarviseutu-lehti.fi,jurvansanomat.fi,komiat.fi,suupohjansanomat.fi,viiskunta.fi#?#._3GUme._1hdYd:has(a[href^="https://pointti.fi"])
+epari.fi,ilkkapohjalainen.fi,jarviseutu-lehti.fi,jurvansanomat.fi,komiat.fi,suupohjansanomat.fi,viiskunta.fi##._3GUme._1hdYd:has(a[href^="https://pointti.fi"])
 epari.fi,ilkkapohjalainen.fi,jarviseutu-lehti.fi,vaasalehti.fi#?#.voice-no-read:has-text(Mainos päättyy)
 epari.fi,jarviseutu-lehti.fi,jurvansanomat.fi,komiat.fi,suupohjansanomat.fi,vaasalehti.fi,viiskunta.fi#?#div[class] > div[id^="sas_"] + div:has-text(Mainos)
 episodi.fi##.bg-elisa-dark
@@ -303,18 +303,18 @@ eralehti.fi##.DfpAdSlot_dfp-ad-slot
 eralehti.fi##.Index_native-ads
 esaimaa.fi,ita-savo.fi,kouvolansanomat.fi,kymensanomat.fi,lansi-savo.fi,uutisvuoksi.fi##div[class^=ad]
 esports.pallomeri.net##.cb-banneri-uusi
-etlehti.fi,hyvaterveys.fi,soppa365.fi#?#.views-row:has(.is-commercial)
+etlehti.fi,hyvaterveys.fi,soppa365.fi##.views-row:has(.is-commercial)
 etn.fi###annonsspalt
 etn.fi###leaderboard
 etn.fi##.annonspekare
 etuovi.com,mikrobitti.fi,rantapallo.fi,talouselama.fi##div[id|=almad]
-etusuora.com#?#.pb30:has(.adsbygoogle)
+etusuora.com##.pb30:has(.adsbygoogle)
 f1-forum.fi##.sponsoredrow
 facebook.com##a[aria-label="Mainostajan linkki"]
 facebook.com##a[aria-label=Mainostaja]
-facebook.com#?#[role="feed"] [data-pagelet^="FeedUnit_"]:has([aria-label="Sponsoroitu"])
+facebook.com##[role="feed"] [data-pagelet^="FeedUnit_"]:has([aria-label="Sponsoroitu"])
 facebook.com#?#[role="feed"] [data-pagelet^="FeedUnit_"]:has(div[class][role="button"][tabindex]:has-text(Sponsoroitu))
-facebook.com#?#div[aria-label="Hakutulokset"][role="main"] [role="feed"] [role="article"]:has(a[aria-label="Sponsoroitu"][href^="/ads/about/"])
+facebook.com##div[aria-label="Hakutulokset"][role="main"] [role="feed"] [role="article"]:has(a[aria-label="Sponsoroitu"][href^="/ads/about/"])
 facebook.com#?#div[role=complementary] > div > div > div > div > div:not([class], [data-visualcompletion]) > span:has([aria-label=Mainostaja])
 facebook.com#?#span#ssrb_feed_start + div > div[class]:has(span[class][dir="auto"] > span[id]:has-text(Sponsoroitu))
 feedi.fi,tanssiin.fi##.alp-advert
@@ -340,7 +340,7 @@ finder.fi##.FrontPageSpots__Ad
 findit.fi##.banner-wrapper
 findit.fi##.banner_middle
 finnkino.fi##.in-list-ad-containers
-finnkino.fi#?#.content-article.h-container:has(#FKM-paraati)
+finnkino.fi##.content-article.h-container:has(#FKM-paraati)
 finnkino.fi,fum.fi,tilt.fi,vuokraovi.com##.advertising
 flashscore.fi##.detailLeaderboard
 fonecta.fi##.map-ad
@@ -371,8 +371,8 @@ futisfani.com,kiekkofani.com,penkkiurheilu.com,uutisankka.com##[href="https://pu
 futisfani.com,kiekkofani.com,penkkiurheilu.com,uutisankka.com##[href="https://www.halvinlaina.fi"]
 futisfani.com,kiekkofani.com,penkkiurheilu.com,uutisankka.com##[href="https://yrityslaina.com"]
 futisforum2.org###div-ff2-top
-futisforum2.org#?#.windowbg3:has(#div-ff2-bottom)
-futissuomi.fi#?#.elementor-widget:has(img[data-image-title^="MAINOS"])
+futisforum2.org##.windowbg3:has(#div-ff2-bottom)
+futissuomi.fi##.elementor-widget:has(img[data-image-title^="MAINOS"])
 gamereactor.fi###adContainer
 gamereactor.fi###ad_topScroller
 gamereactor.fi###bigVideoAd_content
@@ -393,22 +393,22 @@ gekkonen.net##.tdm_block_pricing
 gekkonen.net##.wpforo-ad
 gekkonen.net##a[href^="https://affmore.com/"]
 gekkonen.net##a[href^="https://record.njordaffiliates.com/"]
-gekkonen.net#?#.td_block_wrap.td-pb-border-top.td_flex_block:has(a[href="https://gekkonen.net/nettikasinot/"])
-gekkonen.net#?#.td_block_wrap.td_block_text_with_title:has(a[href^="https://affmore.com/"])
+gekkonen.net##.td_block_wrap.td-pb-border-top.td_flex_block:has(a[href="https://gekkonen.net/nettikasinot/"])
+gekkonen.net##.td_block_wrap.td_block_text_with_title:has(a[href^="https://affmore.com/"])
 gekkonen.net#?#.td_block_wrap.td_block_text_with_title:has-text(/kasino/i)
-gekkonen.net#?#.widget:has(.adsbygoogle)
-gekkonen.net#?#.widget:has([rel^="https://affmore.com/"])
-gekkonen.net,viranomaisuutiset.fi#?#.code-block:has(ins[class="adsbygoogle"])
+gekkonen.net##.widget:has(.adsbygoogle)
+gekkonen.net##.widget:has([rel^="https://affmore.com/"])
+gekkonen.net,viranomaisuutiset.fi##.code-block:has(ins[class="adsbygoogle"])
 glu.fi#?#.box:has-text(Mainos:)
-glu.fi#?#li:has(.adsbygoogle)
-glu.fi#?#ul.link:has(a[href^="http://clk.tradedoubler.com/"])
+glu.fi##li:has(.adsbygoogle)
+glu.fi##ul.link:has(a[href^="http://clk.tradedoubler.com/"])
 gogolf.fi##.is-advertorial
 gogolf.fi##div[id|="div-gpt-ad"]
 gogolf.fi#?#.has-background:has-text(/MAINOS/i)
 gogolf.fi#?#.has-background:has-text(mainos)
-gogolf.fi#?#.is-sidebar > .has-background:has(.is-advertorial)
-gogolf.fi#?#.is-sidebar > .has-background:has(a[href*="utm_medium=banner"])
-gogolf.fi#?#.js-tabpanel > ol > li:has(.is-advertorial)
+gogolf.fi##.is-sidebar > .has-background:has(.is-advertorial)
+gogolf.fi##.is-sidebar > .has-background:has(a[href*="utm_medium=banner"])
+gogolf.fi##.js-tabpanel > ol > li:has(.is-advertorial)
 golfpiste.com###gp-natives
 golfpiste.com##.ad-separatator
 golfpiste.com##.carousel-cell--native
@@ -421,15 +421,15 @@ golfpiste.com##.section--ad__panorama
 golfpiste.com##.section--ad__rectangle
 golfpiste.com##.section-native-list
 golfpiste.com##body.bbpress > .content-wrapper .section--ad
-golfpiste.com#?#div:has(> #gp-native-1)
+golfpiste.com##div:has(> #gp-native-1)
 gti.fi#?#.wall-item__container:has-text(Mainos)
-haat.fi#?#.pad-small.col-md-4.col-sm-6.col-xs-12:has(.b2b-ad-list)
+haat.fi##.pad-small.col-md-4.col-sm-6.col-xs-12:has(.b2b-ad-list)
 halloota.com##.td_block_template_1.td-a-rec-id-custom-spot.td-a-rec.td-block
 halloota.com##a[href$="koronaavastaan.fi/?ref=metrotuotanto"]
 hardelli.com##.td-a-rec-id-sidebar
 hardelli.com#?#div[class=wpb_wrapper][style^="width: 324px;"] > div[data-td-block-uid]:has-text(PELIT)
 hardware.fi##.adsbygoogle + script + br
-hardware.fi#?#br:has(+ .adsbygoogle)
+hardware.fi##br:has(+ .adsbygoogle)
 hardware.fi,kaksplus.fi,metsalehti.fi,uutisankka.com##.advertisement
 hattulaan.fi,reska.fi##.content.single-banner
 hattulaan.fi,reska.fi##.top.panorama.banner
@@ -443,13 +443,13 @@ heili.fi###sp-alabanneri
 heili.fi##.autoboksi.moduletable
 heili.fi,outokummunseutu.fi,pielisjokiseutu.fi,pogostansanomat.fi,prsanomat.fi,ylakarjala.fi##.jattiboksi.moduletable
 helsinkitimes.fi##.banneritem
-helsinkitimes.fi#?#.module:has(.bannergroup)
+helsinkitimes.fi##.module:has(.bannergroup)
 hevosurheilu.fi##[data-test-id="ad"]
 hidastaelamaa.fi###banner-top
-hidastaelamaa.fi#?#.feature:has([href$="/mainosyhteistyo/"])
+hidastaelamaa.fi##.feature:has([href$="/mainosyhteistyo/"])
 hifimaailma.fi##.any-commercial
-hifimaailma.fi#?#.bottomlistarticle:has(.ag-promocolllabel)
-hifimaailma.fi#?#.col-section:has(.ag-promocolllabel)
+hifimaailma.fi##.bottomlistarticle:has(.ag-promocolllabel)
+hifimaailma.fi##.col-section:has(.ag-promocolllabel)
 high.fi###googlejs
 high.fi##div[class*=sub-container]
 high.fi#?#article > .main-link:has(.source:has-text(sponsoroitu))
@@ -477,7 +477,7 @@ hs.fi#?#.embedded:has-text(Markkinapaikka)
 huoltovalikko.com##A[href="http://www.satshop.fi"]
 huonoaiti.fi#?#.col.article-card.item:has-text(Kaupallinen yhteistyö, yhteistyössä)
 huuto.net###hise-items-container
-huuto.net#?#.grid-element-container:has(.hise-link[href^="https://"])
+huuto.net##.grid-element-container:has(.hise-link[href^="https://"])
 hymy.fi##.grid--dfp-slots
 hymy.fi##.sidebar-block a[href^="https://seura.fi/mainos/"]
 hyvaterveys.fi##.pane-sbase-cts-native-native-front
@@ -486,16 +486,16 @@ iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhaj
 iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhajokiseutu.fi,raahenseutu.fi,rantalakeus.fi,siikajokilaakso.fi##.ad-container
 iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhajokiseutu.fi,raahenseutu.fi,rantalakeus.fi,siikajokilaakso.fi##.right-now-widget__item--commercial
 iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhajokiseutu.fi,raahenseutu.fi,rantalakeus.fi,siikajokilaakso.fi#?#.m-contentListItemThumb.-level-1:has-text(Mainos)
-iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhajokiseutu.fi,raahenseutu.fi,rantalakeus.fi,siikajokilaakso.fi#?#.m-managedListing__column.-level-1:has(.-commercial)
+iijokiseutu.fi,kaleva.fi,koillissanomat.fi,lapinkansa.fi,pohjoisenpolut.fi,pyhajokiseutu.fi,raahenseutu.fi,rantalakeus.fi,siikajokilaakso.fi##.m-managedListing__column.-level-1:has(.-commercial)
 ilkkapohjalainen.fi##div[data-lazy-ad-unit-id]
 ilmastointilaitteet.com##.boxi
 iltapulu.fi##div[class=footer-ylempi]
-iltapulu.fi#?#.newsbox:has(> [id^=div-gpt-ad])
+iltapulu.fi##.newsbox:has(> [id^=div-gpt-ad])
 impe.fi##[class^=mainospaikka]
-inferno.fi#?#p:has([href^="https://track.adform.net/"])
+inferno.fi##p:has([href^="https://track.adform.net/"])
 inssinosingot.fi##.button-mainos
 inssinosingot.fi##.footer-1.footer.footer-widgets
-inssinosingot.fi#?#div[class="row align-center"]:has([class$=lazy-load-active])
+inssinosingot.fi##div[class="row align-center"]:has([class$=lazy-load-active])
 inssinosingot.fi,koeajolle.com##.block-mainos
 irc-galleria.net##div[id^=open_]
 irc-galleria.net,tilannehuone.fi##div[id^=Nostemedia_Desktop]
@@ -504,12 +504,12 @@ is.fi##a.block[href^="https://www.admanager.fi/"]
 is.fi##div.sadblob-loading
 iskelma.fi##section.sbs-articleitems[data-module_position_id="814"]
 iskelma.fi,radionova.fi,voice.fi#?#.sbs-articleitems:has(.right-column-header + .articles-container .article-item:only-child .sponsored)
-iskelma.fi,radionova.fi,voice.fi#?#a.article-item:has(.sponsored)
-iskelma.fi,radionova.fi,voice.fi#?#div.item:has(.sponsored)
+iskelma.fi,radionova.fi,voice.fi##a.article-item:has(.sponsored)
+iskelma.fi,radionova.fi,voice.fi##div.item:has(.sponsored)
 jaakiekonmmkisat.com,jalkapallonmmkisat.com,ruuhkavuodet.fi##div[class|="g g"]
-jaatama.fi#?#.box--transparent:has(.advert)
+jaatama.fi##.box--transparent:has(.advert)
 jaatama.fi,maastohiihto.com,retkilehti.fi,riistalehti.fi##.advert
-jahtimedia.fi#?#.latest-post-link:has(.mainos)
+jahtimedia.fi##.latest-post-link:has(.mainos)
 jatkoaika.com###cmorelink
 jatkoaika.com##.inline-txtad
 jatkoaika.com##div[class="block block-block"]
@@ -521,18 +521,18 @@ jvg.fi##[href="https://www.nettikasinovertailu.info/"]
 kaaoszine.fi##.collab
 kaaoszine.fi##.collaboration
 kaaoszine.fi##.emp-ad
-kaaoszine.fi#?#.content-section > .g:has([id^="gpt-desktop-inside-article"])
-kaaoszine.fi#?#.right-inner-section:has(#gpt-desktop-side)
+kaaoszine.fi##.content-section > .g:has([id^="gpt-desktop-inside-article"])
+kaaoszine.fi##.right-inner-section:has(#gpt-desktop-side)
 kaasujalka.fi##[src^="https://kaasujalka.fi/assets/banners"]
-kaasujalka.fi#?#.widget-container:has([class^=ad_])
+kaasujalka.fi##.widget-container:has([class^=ad_])
 kaksplus.fi##.ad-mob_description
 kaksplus.fi##.placeholder
 kaksplus.fi##.wp-block-otavamedia-google-ad-slot
 kaksplus.fi#?##huomiotekstiotsikko:has-text(Mainos)
-kaksplus.fi#?#.frosmo_popup:has(.popup_advertiser)
-kaksplus.fi#?#.is-background-gray-light-3:has([id^=dfp__])
+kaksplus.fi##.frosmo_popup:has(.popup_advertiser)
+kaksplus.fi##.is-background-gray-light-3:has([id^=dfp__])
 kaksplus.fi#?#.wp-block-otavamedia-section-management:has-text(Kaupallinen yhteistyö)
-kaksplus.fi#?#li.grid__item:has([id^=dfp__native-card])
+kaksplus.fi##li.grid__item:has([id^=dfp__native-card])
 kalamies.com##.custom_banners_big_linkbefore-content
 kalamies.com##.custom_banners_big_linkwidget
 kalamies.com##[class^=custom_banners_big_linkcontent]
@@ -542,10 +542,10 @@ kalastus.com###mini-panel-autodoc_150x50
 kalastus.com##.gam-holder
 kaleva.fi###puff-container
 kaleva.fi##div[class=lyta-lazy-load]
-kaleva.fi#?#.m-contentListItemThumb:has(> div > div > div[class^=m-contentListItemThumb__advertisement])
-kaleva.fi#?#.m-managedListing__column:has(> div > div > div > div[class^=m-contentListItem__advertisement])
+kaleva.fi##.m-contentListItemThumb:has(> div > div > div[class^=m-contentListItemThumb__advertisement])
+kaleva.fi##.m-managedListing__column:has(> div > div > div > div[class^=m-contentListItem__advertisement])
 kaleva.fi#?#.media-site__widget-container:has( * .media-widget__title:has-text(Kaupallinen yhteistyö))
-kaleva.fi#?#aside.sidebar__column-container:has(.-ad)
+kaleva.fi##aside.sidebar__column-container:has(.-ad)
 kaleva.fi,lapinkansa.fi###outstream-container
 kamera-lehti.fi###sidebar .simple-image > [href]:not([href^="https://kamera-lehti.fi"])
 kamera-lehti.fi###sidebar .widget[id|="custom_html"]
@@ -556,8 +556,8 @@ kangasalansanomat.fi#?#.td-pb-span6:has-text(Kaupallinen yhteistyö)
 kansalainen.fi##a[href="https://www.kielletytkirjat.com/"]
 kansalainen.fi##a[href^="https://revoltnoir.com"]
 kansalainen.fi##div[id^=ads]
-kansalainen.fi#?#.herald-module:has(.adsbygoogle)
-kansalainen.fi#?#.herald-module:has([href^="https://revoltnoir.fi/"])
+kansalainen.fi##.herald-module:has(.adsbygoogle)
+kansalainen.fi##.herald-module:has([href^="https://revoltnoir.fi/"])
 kansantahto.fi##.elementor-element-2770b68
 kansantahto.fi##.elementor-element-3e26be8
 kansantahto.fi##.elementor-element-44ffbd5
@@ -568,14 +568,14 @@ kansantahto.fi#?#.strike:has-text(Mainos)
 karjalainen.fi##a[href="https://punamustamedia.portal.worldoftulo.com/v2/shop/dtabkaiku"]
 karjalainen.fi#?#.breaking-news-container:has-text(mainos:)
 karjalainen.fi#?#.card-container:has-text(Mainos alkaa)
-karjalainen.fi#?#a[href*=kiinnostuitko]:has([alt=banneri])
+karjalainen.fi##a[href*=kiinnostuitko]:has([alt=banneri])
 karjalainen.fi,sammysatv.com##center
-kauppalehti.fi#?##coral-talk + div[class]:has(a[href^="https://www.kauppalehti.fi/kumppanisisallot/"])
-kauppalehti.fi#?#div[class][width]:has(> .ad)
+kauppalehti.fi###coral-talk + div[class]:has(a[href^="https://www.kauppalehti.fi/kumppanisisallot/"])
+kauppalehti.fi##div[class][width]:has(> .ad)
 kauppalehti.fi#?#main:not(> h2:has-text(Kumppanisisältöä)) [class][data-test] ~ div[class]:has(> a[href^="https://www.kauppalehti.fi/kumppanisisallot/"])
 kauppalehti.fi#?#main:not(> h2:has-text(Kumppanisisältöä)) a[href^="https://www.kauppalehti.fi/kumppanisisallot/"][target="_self"]
 kauppalehti.fi,mediuutiset.fi##aside > div[class] > a[href*="/kumppanisisallot/"]
-kauppalehti.fi,talouselama.fi#?#div[class]:has(> .lazyload-wrapper > .etua-react-embed)
+kauppalehti.fi,talouselama.fi##div[class]:has(> .lazyload-wrapper > .etua-react-embed)
 kauppojen-aukioloajat.fi###search-top-wide-ad
 kauppojen-aukioloajat.fi###specific-bottom-rectangle-ad
 kauppojen-aukioloajat.fi###specific-bottom-wide-ad
@@ -602,7 +602,7 @@ kiinteistoposti.fi##.kiint-widget
 kiinteistoposti.fi#?#.featuredpost:has(.gb-post-grid-section-title:has-text(Kaupallinen yhteistyö))
 kilipailut.fi##.bannerlink
 kilokalori.net##kc-ad
-kilokalori.net#?#.hidden-print.panel-default.panel:has(kc-ad)
+kilokalori.net##.hidden-print.panel-default.panel:has(kc-ad)
 kinuskikissa.fi##app-ad
 klangi.fi,paakallo.fi,suomenautolehti.fi##.banner
 kodinviilennys.fi#?#.wp-block-image:has-text(mainos)
@@ -612,7 +612,7 @@ koeajolle.com##.code-block
 koeajolle.com#?#.post p:has-text(Mainos:)
 kohokohta.com#?#.text-center:has-text(loadAd)
 kokemaenjokilaakso.fi#?#.ai-attributes:has-text(Mainos)
-kokemaenjokilaakso.fi#?#p:has([alt^=Mainos])
+kokemaenjokilaakso.fi##p:has([alt^=Mainos])
 kokemakelainen.net###text-81
 kokemakelainen.net###text-82
 konekuriiri.fi,koneporssi.com##.banners
@@ -625,9 +625,9 @@ kotikokki.net###partners-container-big
 kotikokki.net##.kotikokki_ensighten_ad
 kotiliesi.fi##.article-continues
 kotiliesi.fi##.card--is-sponsored
-kotiliesi.fi#?#.wp-block-otavamedia-section-management li:has([id^=dfp__])
+kotiliesi.fi##.wp-block-otavamedia-section-management li:has([id^=dfp__])
 kotiliesi.fi,suomenkuvalehti.fi##.wp-block-otavamedia-google-ad-slot
-kotimaa.fi#?#div[class=" "] > .rendered_board_widget:has(.kotimaa-adform-widget)
+kotimaa.fi##div[class=" "] > .rendered_board_widget:has(.kotimaa-adform-widget)
 kotimaatutuksi.fi###nmbc
 kotimaatutuksi.fi##.artikkelim-jatkuu
 kotimaatutuksi.fi##.headerau
@@ -644,26 +644,26 @@ kukasoitti.com##div[class=main-bottom]
 kuljetusnet.fi###middle
 kuljetusnet.fi##div[class*=banner]
 kulutusluottovertailu.fi##.fusion-carousel
-kuntalehti.fi#?#.g:has(.gofollow)
+kuntalehti.fi##.g:has(.gofollow)
 kuntatekniikka.fi##.g-1
-kuntsari.fi#?#.wpb_wrapper.wpb_text_column.td_block_wrap:has([auto-grid-data*="mainos"])
+kuntsari.fi##.wpb_wrapper.wpb_text_column.td_block_wrap:has([auto-grid-data*="mainos"])
 kuvake.net###ticker
 kuvake.net,kuvaton.com##.addme
 kuvaton.com,viikonloppu.com##[href^="https://www.kasinokaverit.com/"]
 kuvaton.com,viikonloppu.com##[href^="https://www.lainaovi.fi/"]
 kymensanomat.fi,ess.fi##.page-notes > .note--highlight
-laitilansanomat.fi#?#.wpb_wrapper.wpb_text_column.td_block_wrap:has([auto-grid-data*=mainos])
+laitilansanomat.fi##.wpb_wrapper.wpb_text_column.td_block_wrap:has([auto-grid-data*=mainos])
 laliiga.com,leijonat.com,suomif1.com##.lead-collector-cta
 lapinkansa.fi###content1-container
-lapinkansa.fi#?#div[class="m-contentListItemThumb -ctx-frontpage-now -level-1"]:has(> div > div > [class^=m-contentListItemThumb__advertisement])
-lapinkansa.fi#?#div[class="m-managedListing__column -ctx-index -level-1 -cols-2"]:has(> div > div > div > div[class^=m-contentListItem__advertisement])
+lapinkansa.fi##div[class="m-contentListItemThumb -ctx-frontpage-now -level-1"]:has(> div > div > [class^=m-contentListItemThumb__advertisement])
+lapinkansa.fi##div[class="m-managedListing__column -ctx-index -level-1 -cols-2"]:has(> div > div > div > div[class^=m-contentListItem__advertisement])
 lapuansanomat.fi##.tilaa-tasta
 lapuansanomat.fi##.ylabanner1
 lauttakyla.fi##.box-banner a[href^="/redirect/"]
 lauttakyla.fi##.fullwidth-imagebanner
 lauttakyla.fi##.hasordercontent.orange-bg
 lauttakyla.fi##.mainbanner
-lauttakyla.fi#?#.fullwidth-banner:has(> a[href="https://www.lauttakyla.fi/tilaa/"])
+lauttakyla.fi##.fullwidth-banner:has(> a[href="https://www.lauttakyla.fi/tilaa/"])
 lbaanijakuva.fi##.adremark
 lbaanijakuva.fi##.popup-overlay
 leffatykki.com###ad-300x150
@@ -674,7 +674,7 @@ lehtikeidas.fi##.header-widget [href^="https://aslinkhub.com/"]
 leijonat.com,suomikiekko.com##.pnadg-container
 leijonat.com,suomiurheilu.com##[href$="/pitkavetovihjeet/"]
 lennot.rantapallo.fi#?#.flights.type-provider:has-text(Mainos)
-lentopallo.info,murtopallo.net#?#li:has([href^="https://track.adtraction.com/"])
+lentopallo.info,murtopallo.net##li:has([href^="https://track.adtraction.com/"])
 liberolehti.fi#?#[id|=etusivu-bottom-full]:has(.mainos)
 lily.fi,meillakotona.fi,terve.fi##div[class^="FeedList__AdWrapper-"]
 listafriikki.com,tanssiin.fi##.mvp-post-ad-wrap
@@ -689,9 +689,9 @@ ls24.fi##.page-section--commercial
 ls24.fi##.palvelupankki-banner
 ls24.fi##aside[class=sidebar] > [class^="advertisement ad advertisement"] + [class^="advertisement ad advertisement"] + section[class^=article-list]:last-of-type
 ls24.fi##div[class^=advertisement]
-ls24.fi#?#.article-block__list-article:has(a[href^="https://ls24.fi/kaupallinen-yhteistyo/"])
+ls24.fi##.article-block__list-article:has(a[href^="https://ls24.fi/kaupallinen-yhteistyo/"])
 ls24.fi#?#.article-list--article:has-text(Kaupallinen yhteistyö)
-ls24.fi#?#.js-article-block:has(span[class$=commercial-label])
+ls24.fi##.js-article-block:has(span[class$=commercial-label])
 ls24.fi#?#.js-article-block:has(span[class$=commercial-label]) + .article-blocks-2022-divider
 ls24.fi#?#section[class="page-section page-section--no-main-article"]:has-text(Kaupallinen yhteistyö)
 lumipallo.fi#?#div.row:not(:has(article)):has([src="//s1.adform.net/banners/scripts/adx.js"])
@@ -709,39 +709,39 @@ m.nettimokki.com##.itemlist > li:not(.block_list_li)
 m.tori.fi##.appnexus-container
 maalampofoorumi.fi##div#sponsor
 maaseuduntulevaisuus.fi##div[class*="ArticleTeaserGroup_nativeAd"]
-maaseuduntulevaisuus.fi#?#div[class^=MainLane_laneItem]:has(div[class^=ArticleBanner_advertorial])
+maaseuduntulevaisuus.fi##div[class^=MainLane_laneItem]:has(div[class^=ArticleBanner_advertorial])
 maaseutumedia.fi##.header_banner
 maaseutumedia.fi##.textwidget
 maastohiihto.com##.paid-content-wrapper
 markkinointiuutiset.fi##div[class|="ad-section"]
-matkabongaukset.fi#?#.widget_block:has(.matka-nostemedia-oikeapalsta)
+matkabongaukset.fi##.widget_block:has(.matka-nostemedia-oikeapalsta)
 matkapuhelinfoorumi.fi##div.structItem.is-prefix53
 mediaviikko.fi##a[href="https://mailapro.fi/"]
 mediaviikko.fi##a[href="https://urheilutuet.fi/"]
 mediaviikko.fi##a[href="https://vesikourut.fi/"]
 mediaviikko.fi##amp-layout[amp-access^="popups."][role=button]
-mediaviikko.fi#?#.wp-block-column:has(aside figure > a[href="https://www.hopealanka.fi"])
+mediaviikko.fi##.wp-block-column:has(aside figure > a[href="https://www.hopealanka.fi"])
 mediuutiset.fi##aside > div[class] > a[href="/kumppanisisaltoa"]
 mediuutiset.fi#?#body:not(#skyscraper-height-div > div > div:has-text(Kumppanisisältöä)) section > a[href^="https://www.mediuutiset.fi/kumppanisisallot"]
 mediuutiset.fi#?#body:not(.is-style-kumppanisisallot):not(#skyscraper-height-div > div > div:has-text(Kumppanisisältöä)) div[class]:has(> a[href^="https://www.mediuutiset.fi/kumppanisisallot/"]:not(a[class^=site-header]))
-mediuutiset.fi#?#div[class]:has(> a[href="/kumppanisisaltoa"])
+mediuutiset.fi##div[class]:has(> a[href="/kumppanisisaltoa"])
 mediuutiset.fi#?#div[width]:has([id|="almad"]:not([id|="almad-mobileParade"]))
 meillakotona.fi##div[class^=NativeAdSpotlight__Component]
 meillakotona.fi##div[class^=pageFeed__topAdSlot]
-meillakotona.fi#?#div[class^=ContentFlowBlock__CardContainer]:has(div[class*=ContentCard__AdLabel])
-meillakotona.fi#?#div[class^="transitionSlot__component"]:has(div[class^="feedItem__commercial"])
+meillakotona.fi##div[class^=ContentFlowBlock__CardContainer]:has(div[class*=ContentCard__AdLabel])
+meillakotona.fi##div[class^="transitionSlot__component"]:has(div[class^="feedItem__commercial"])
 meillakotona.fi#?#div[class^=transitionSlot__component][class*=layout__container]:has-text(MAINOS)
 meillakotona.fi,terve.fi##div[class*=feed__adSlot]
 metropoli.net##.ads-desktop
 metropoli.net##.ads-mobile
-metropoli.net#?#.block-box.news-post:has(a[href^="https://www.metropoli.net/rahapelit/"])
+metropoli.net##.block-box.news-post:has(a[href^="https://www.metropoli.net/rahapelit/"])
 metsalehti.fi##.aprofit
 metsalehti.fi##.section--native-left
 metsalehti.fi##.teaser--partner
 metsalehti.fi##.teaser-top-banner--partner
 metsalehti.fi##[data-set="main-ad"]
 metsastajaliitto.fi#?#.frontpage-ad-item:not(:has([href^="https://metsastajaliitto.fi/"]))
-metsastajaliitto.fi#?#.view-id-jahtimedia_latest .list-item:has([href^="https://jahtimedia.fi/mainokset/"])
+metsastajaliitto.fi##.view-id-jahtimedia_latest .list-item:has([href^="https://jahtimedia.fi/mainokset/"])
 metsastysjakalastus.fi##.Index_native-ads
 metsastysjakalastus.fi,rakennusmaailma.fi,tekniikanmaailma.fi##.Article_native-ads
 metsastysjakalastus.fi,rakennusmaailma.fi,tekniikanmaailma.fi##.in-text-ad-slot-wrapper
@@ -790,7 +790,7 @@ muropaketti.com##.widget_ads_carousel
 muropaketti.com##.widget_adwidget
 muropaketti.com##.widget_hintaopasbestprice
 muropaketti.com##SECTION[id*=hintaopaspopular]
-muropaketti.com#?#article.grid__item_1-2:has(> div.nativead)
+muropaketti.com##article.grid__item_1-2:has(> div.nativead)
 muropaketti.com#?#article.grid__item_md-1-5.grid__item_1:has-text(Mainos)
 mutsimedia.fi##.add-banner
 mvlehti.net###ads-sidebar-top
@@ -806,7 +806,7 @@ mvlehti.net##.wp-block-image > figure[class] > a[href]
 mvlehti.net##section.post-single > figure[class].wp-block-image > a[href][target][rel] > img[class][src]
 mvlehti.net#?#.entry-content > h3:has-text(kasino)
 mvlehti.net#?#[class|=featured-post]:has-text(/rahapeli|kasino/i):has(a[href*="/202"])
-mvlehti.net#?#footer .quote:has(figure[class].wp-block-image > a[href])
+mvlehti.net##footer .quote:has(figure[class].wp-block-image > a[href])
 mvlehti.net#?#li:has(a[href*="/202"]):has(a[href*="nettikasino"])
 myheritage.fi##.promotional_banner_root
 nainen.com##[href="https://www.kasinokaverit.com/ilmaiskierroksia-nettikasinoilla/"]
@@ -815,12 +815,12 @@ napsu.fi###banneriwrapper
 napsu.fi##.mobilead
 navigatormagazine.fi##.mob_panorama
 navigatormagazine.fi,promaintlehti.fi##.panorama
-nelonen.fi#?#.chakra-container + div[class]:has(> div[class] > [data-adfscript^="track.adform.net/"])
+nelonen.fi##.chakra-container + div[class]:has(> div[class] > [data-adfscript^="track.adform.net/"])
 netti-tv.fi##div[style^="min-height:"][style$=";text-align:center"]
 netti-tv.fi,synonyymit.fi##div[style^="min-height:"]
 nettiauto.com##.homepage-adspot
 nettiauto.com#?##art_right_banner:has(> [id|="almad"])
-nettiauto.com,nettikone.com#?##article_sh li:has(.homepage-adspot-list)
+nettiauto.com,nettikone.com###article_sh li:has(.homepage-adspot-list)
 nettitrendi.fi##.node__content .block[class$="kampanja"]
 nettitrendi.fi##.topbar
 nettitrendi.fi##div[id^="block-credigo"]
@@ -828,18 +828,18 @@ nettitrendi.fi#?#.block-block-content:has-text(Jatkuu mainoksen alla)
 nopeustesti.com###offer
 nopeustesti.com###tulos-etu
 nyan.ax##.mobileads
-nyan.ax#?#.wpb_column.vc_column_container.td-pb-span8:has([src$="adsbygoogle.js"])
-nyan.ax#?#.wpb_column.vc_column_container.td-pb-span8:has(a[onclick*='banner'])
+nyan.ax##.wpb_column.vc_column_container.td-pb-span8:has([src$="adsbygoogle.js"])
+nyan.ax##.wpb_column.vc_column_container.td-pb-span8:has(a[onclick*='banner'])
 olutposti.fi##.advertoriaalit
 olutposti.fi#?#.aside.widget:has-text(Mainos)
 omalahio.fi##.mainos-top
 opensubtitles.org#?#fieldset:has-text(Poista mainos)
-orimattilansanomat.fi#?#.textwidget:has(.orimad-adlabel)
+orimattilansanomat.fi##.textwidget:has(.orimad-adlabel)
 orivedensanomat.fi###sidebar [href="https://www.loytotex.fi/tarjoukset"]
 orivedensanomat.fi##.CMAC_AdChangerWidget.widget
 osterbottenstidning.fi,sydin.fi,vasabladet.fi##.online-ad-container
 osterbottenstidning.fi,sydin.fi,vasabladet.fi##.online-teaser--advertorial
-outokummunseutu.fi,pielisjokiseutu.fi,pogostansanomat.fi,ylakarjala.fi#?#.sp-module:has(.tassaWidget)
+outokummunseutu.fi,pielisjokiseutu.fi,pogostansanomat.fi,ylakarjala.fi##.sp-module:has(.tassaWidget)
 pakkotoisto.com##.samBannerUnit
 pakkotoisto.com##.samCodeUnit
 pakkotoisto.com##.td-header-sp-recs
@@ -864,7 +864,7 @@ pienimatkaopas.com##[id^=pm_mp_tekstissa]
 pienimatkaopas.com#?##mainos .otsikko:has-text(Lue myös) + div ~ *
 piipaa.info##[data-id="adsense"]
 pirkkalainen.fi##.omamainos-PIR
-pirkkalainen.fi#?#.ultp-block-wrapper:has(.ultp-cat-mainosartikkelit)
+pirkkalainen.fi##.ultp-block-wrapper:has(.ultp-cat-mainosartikkelit)
 pkank.fi##.ad-assigned.panoraamabanneri
 pointti.fi##.after-ad
 pointti.fi##.before-ad
@@ -877,19 +877,19 @@ pottupellossa.fi#?#.widget_text:has-text(Mainos)
 projektiuutiset.fi##.proje-widget
 projektiuutiset.fi##.uusi-ylabanneri
 proshop.fi##a[data-action="campaignClick"][href="/Philips-Hue"]
-proshop.fi#?#.site-bannerCampaignElement:has(img[src^="/Images/PROSHOP-LIFESTYLE-FRONTPAGE-BANNER"])
-proshop.fi#?#.site-top-banner:has(a[data-action="campaignClick"][data-name$="Frontpage takeover"][href^="/Lego-Christmas"])
+proshop.fi##.site-bannerCampaignElement:has(img[src^="/Images/PROSHOP-LIFESTYLE-FRONTPAGE-BANNER"])
+proshop.fi##.site-top-banner:has(a[data-action="campaignClick"][data-name$="Frontpage takeover"][href^="/Lego-Christmas"])
 pt-media.org###custom_html-63
 pt-media.org###text-32
 pt-media.org##[href="https://pt-media.org/pikakasinot/"]
 pt-media.org##[href^="https://kasinopartio.com/"]
-pt-media.org#?#section:has(> a[href="https://nocompromiseclothing.com/"])
+pt-media.org##section:has(> a[href="https://nocompromiseclothing.com/"])
 puheenaiheet.fi##div[class=wpb_wrapper]
 puheenvuoro.uusisuomi.fi,vapaavuoro.uusisuomi.fi##.partner-blog-list
 puheenvuoro.uusisuomi.fi,vapaavuoro.uusisuomi.fi##.side-list.commercial-blog-studio
 puheenvuoro.uusisuomi.fi,vapaavuoro.uusisuomi.fi##a[class*=commercial-blog-card]
-puhelinvertailu.com#?#br:has(+ br + ins[class=adsbygoogle])
-puhelinvertailu.com#?#br:has(+ ins[class=adsbygoogle])
+puhelinvertailu.com##br:has(+ br + ins[class=adsbygoogle])
+puhelinvertailu.com##br:has(+ ins[class=adsbygoogle])
 puskaradio.net##.all-adds
 radionova.fi##section.sbs-articleitems[data-module_position_id="640"]
 radiovoima.fi##.block-radiovoima-advertisements
@@ -898,7 +898,7 @@ rakennusmaailma.fi,tekniikanmaailma.fi##.FrontPage_native-ads
 rakentaja.fi##div#kauppa_hot
 rakentaja.fi##div[id^=banner]
 rakentaja.fi##img#js_ad
-rakentaja.fi#?##dimScreenAll:has([data-category="DisplayAD"])
+rakentaja.fi###dimScreenAll:has([data-category="DisplayAD"])
 rantapallo.fi##.ad-info-bar
 rantapallo.fi##.front-page-box-ad
 rantapallo.fi##.lomakone-results-skyscrapers
@@ -921,14 +921,14 @@ riimihaku.fi##.top-banner
 riistalehti.fi##.riist-content
 riistalehti.fi##div[id|=riist][style*="text-align: center"]
 ristinvoitto.fi##a[href*="subaction=bannerredirect"]:not(a[href*="-rv-tilaus"])
-rumba.fi#?#.bg-white.w-full.py-2.px-4:has(.poppartners)
-ruuhkavuodet.fi#?#.widget_block:has(#nm-300x600-300x300)
+rumba.fi##.bg-white.w-full.py-2.px-4:has(.poppartners)
+ruuhkavuodet.fi##.widget_block:has(#nm-300x600-300x300)
 sammysatv.com##a[href*=banner]
 satakunnanviikko.fi##.panoraama_etus
 seiska.fi##article[data-section="kaupallinen yhteistyö"]
-seiska.fi#?##article-body .article div[class]:has(> .ad-container)
+seiska.fi###article-body .article div[class]:has(> .ad-container)
 seiska.fi#?##article-body .article div[class^="sc-"]:has-text(/Juttu jatkuu ilmoituksen jälkeen|ilmoitus päättyy/i)
-seura.fi#?#.grid__item_lg-1.grid__item_1:has(.dfp-advertisement)
+seura.fi##.grid__item_lg-1.grid__item_1:has(.dfp-advertisement)
 seura.fi#?#.wp-block-column:has(> [id|="dfp__native-card"])
 seura.fi#?#li:has(> [id|="dfp__native-card"])
 seura.fi#?#section[class=entry-body] > p:has-text(/^\xA0$/)
@@ -937,14 +937,14 @@ seutumajakka.fi##.section--full-size-ad-carousel
 sevendays.vasabladet.fi##.AutomaticDfpWidget
 sevendays.vasabladet.fi##.DfpWidget
 sijoittaja.fi##body.page:not(.home) .g.g-3
-sijoittaja.fi#?#.g-single:has(.hs-cta-wrapper)
+sijoittaja.fi##.g-single:has(.hs-cta-wrapper)
 sijoittaja.fi#?#body.home .container > div[style="z-index:1800; margin-bottom:40px;"]:has(.g-single > .hs-cta-wrapper)
-sijoittaja.fi#?#body.single-post .container[style]:has(.g-single > .hs-cta-wrapper)
+sijoittaja.fi##body.single-post .container[style]:has(.g-single > .hs-cta-wrapper)
 sijoitustieto.fi##.view-2019-ajankohtaiset-tarjoukset
 sijoitustieto.fi##.view-banneripaikka-etusivuoikea1
 sijoitustieto.fi#?#p > em > strong:has-text(Kaupallinen yhteistyö:)
 sjofart.ax##.elementor-location-header .topp
-sjofart.ax#?#.ae-bg-gallery-type-default.elementor-section-height-default.elementor-section-boxed.elementor-hidden-phone.has_ae_slider:has([src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"])
+sjofart.ax##.ae-bg-gallery-type-default.elementor-section-height-default.elementor-section-boxed.elementor-hidden-phone.has_ae_slider:has([src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"])
 sketsi.net##footer > .container.tdt-ad-wrap
 somerolehti.fi###auto-grid-container-5c470b0150cba
 sportti.com##[href^="http://ads.leovegas.com/"]
@@ -962,7 +962,7 @@ sportti.com#?#div[style="padding-bottom:10px;margin-bottom:6px;border-top:1px so
 sportti.com#?#table[width]:has(script[class=teads]):not(:has(.category_story_unit))
 sportti.com#?#tr:has(+ tr:has(script))
 sportti.com#?#tr:has-text(.loadAd)
-sss.fi#?#.td_block_wrap:has([href="https://www.sss.fi/category/mainos/"])
+sss.fi##.td_block_wrap:has([href="https://www.sss.fi/category/mainos/"])
 sss.fi#?#aside.widget_text:has-text(MAINOS)
 styleroom.fi#?#.bg-box:has([id|=placement-ad-grid])
 suomela.fi##.ad
@@ -973,7 +973,7 @@ suomela.fi##a[href^="https://www.autodoc.fi/"]
 suomela.fi##div[id$=paraati]
 suomela.fi##div[id|=banner]
 suomela.fi#?#.custom-title:has-text(Kaupalliset yhteistyöt)
-suomela.fi#?#.no-print.justify-center.flex:has([data-ad-unit-id])
+suomela.fi##.no-print.justify-center.flex:has([data-ad-unit-id])
 suomen118.fi###layout-banner-right
 suomenautolehti.fi##.banner_wide
 suomenautolehti.fi##.site-footer__banners
@@ -986,19 +986,19 @@ suomi24.fi##.editorial-slots
 suomi24.fi##div[class*=Ad__AdWrapper]
 suomi24.fi##div[class^=HomePage__HeaderAd]
 suomi24.fi##div[id^=viihdes24_desktop-sidebar]
-suomi24.fi#?#div[class^=ThreadGridItemWrapper__CardCol]:has([class^=AdLivewrapped__AdWrapper])
+suomi24.fi##div[class^=ThreadGridItemWrapper__CardCol]:has([class^=AdLivewrapped__AdWrapper])
 suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com##[href$="/nettikasinot/"]
 suomif1.com,suomifutis.com,suomikiekko.com,suomikoris.com,suomiurheilu.com##[href$="/nettikasinot/"] + .dropdown-toggle
 suomif1.com,suomifutis.com,suomikiekko.com,valioliiga.com##[data-bottom-floater]
-suomifutis.com#?#.menu-item:has([href*="/veikkausvihjeet"])
-suomikiekko.com#?#.menu-item:has([href$="/pitkavetovihjeet/"])
+suomifutis.com##.menu-item:has([href*="/veikkausvihjeet"])
+suomikiekko.com##.menu-item:has([href$="/pitkavetovihjeet/"])
 suomimobiili.fi##.artikkelimainos
 suomimobiili.fi##.headermainos
 suomimobiili.fi##.natiivilinkit
-suomimobiili.fi#?#.posts-list > .list-item:has([href="https://suomimobiili.fi/kategoria/sponsoroitu/"])
+suomimobiili.fi##.posts-list > .list-item:has([href="https://suomimobiili.fi/kategoria/sponsoroitu/"])
 suomimobiili.fi#?#.posts-listing-list-alt-b:has-text(Artikkeleita kumppaneilta)
 superlehti.fi##.ad-banner-lift
-supla.fi#?#[data-element-type="CardDefault"] div[class^=CardBg]:has(> a[href^="https://kampanjat.mainos.sanoma.fi/"])
+supla.fi##[data-element-type="CardDefault"] div[class^=CardBg]:has(> a[href^="https://kampanjat.mainos.sanoma.fi/"])
 svl.fi##.mainos_banner1
 svl.fi##.widget > a[href^="https://www.nettikirjakauppa.com/"]
 taisto.org###mw-data-after-content > div
@@ -1007,8 +1007,8 @@ talouselama.fi##body:not(.is-style-kumppanisisallot) a[href^="https://www.talous
 talouselama.fi#?#.lazyload-wrapper:has([id|=almad])
 talouselama.fi#?#[id|=podcasti]:has-text(Kaupallinen Yhteistyö)
 talouselama.fi#?#body:not(.is-style-kumppanisisallot) [class]:has(> a[href^="https://www.talouselama.fi/kumppanisisallot/"]):not(section)
-talouselama.fi#?#div.article-body > div:has(> div.LazyLoad.is-visible)
-talouselama.fi#?#div[width]:has(.lazyload-wrapper)
+talouselama.fi##div.article-body > div:has(> div.LazyLoad.is-visible)
+talouselama.fi##div[width]:has(.lazyload-wrapper)
 talouselama.fi#?#li:has-text(MAINOS)
 taloustaito.fi##.bannerarea
 talviopas.fi,turisti-info.fi##.sidebar-banners
@@ -1034,13 +1034,13 @@ tekniikkatalous.fi##section > div > a[href^="https://www.tekniikkatalous.fi/kump
 tekniikkatalous.fi#?#.article-body > div[class]:has(> span:has-text(KAUPALLINEN YHTEISTYÖ) + a[href^="https://koulutus.almatalent.fi/"])
 tekniikkatalous.fi#?#div#skyscraper-height-div > aside > div > div > a:has-text(Kaupallinen yhteistyö)
 tekniikkatalous.fi#?#div#skyscraper-height-div > section > div > a:has-text(Kaupallinen yhteistyö)
-tekniikkatalous.fi,tivi.fi#?#[width]:has(.lazyload-wrapper)
-telsu.fi#?#.ch:has(em>a)
+tekniikkatalous.fi,tivi.fi##[width]:has(.lazyload-wrapper)
+telsu.fi##.ch:has(em>a)
 telsu.fi#?#.ch:has-text(/SPON|SPONS|SPONSO|SPONSOR|SPONSORO|SPONSOROI|SPONSOROIT|SPONSOROITU/)
 telsu.fi#?#.ch:has-text(/SP(O|0)NSOROITU/)
 tennis.fi##.ad-blocks
 tervareitti.fi##.advertisement-banner-row
-tervareitti.fi#?#.article-container.shadow-sm.col:has(img[alt^="Oma tilausmainos"])
+tervareitti.fi##.article-container.shadow-sm.col:has(img[alt^="Oma tilausmainos"])
 terve.fi##div[class|=ProductRecommendationCarousel__CarouselContainer]
 terve.fi#?#div[class^=PageElementFeedItem__Container]:has-text(Mainos)
 terve.fi#?#div[class^=transitionSlot__component][class*=layout__container]:has-text(KAUPALLINEN YHTEISTYÖ)
@@ -1054,7 +1054,7 @@ tiedonantaja.fi##[class*="block-boxes-ad-300x250"]
 tiendeo.fi###header-standard-container
 tiendeo.fi##[data-testid^="div-gpt-ad-"]
 tiketti.fi###front_big_event > span
-tiketti.fi#?#.itemwide:has([href="https://www.nextory.fi/partner-collaboration/tiketti/"])
+tiketti.fi##.itemwide:has([href="https://www.nextory.fi/partner-collaboration/tiketti/"])
 tilannehuone.fi##[class^=mainos]:not(:only-child)
 tilannehuone.fi#?##cnt_lista tr:has(.mainosinline) + tr:has(> .divid)
 tilannehuone.fi#?##cnt_lista tr:has-text(/^\s$/):has(+ tr:has(.mainosinline))
@@ -1062,7 +1062,7 @@ tilannehuone.fi#?#.contentti:has(> .mainos-mob:only-child)
 tilannehuone.fi#?#.contentti:has(> .mainos_yla:only-child)
 tilisanomat.fi##.ctaad
 tilt.fi##[data-mobile-ad-unit-id]
-tilt.fi#?#div[class="w-full bg-black border-gray-200 border-b"]:has(a[href^="http://pubads.g.doubleclick.net/"])
+tilt.fi##div[class="w-full bg-black border-gray-200 border-b"]:has(a[href^="http://pubads.g.doubleclick.net/"])
 tinderinparhaat.com##.adf-placement-top
 tivi.fi##aside > div[class] > a[href^="https://www.tivi.fi/kumppanisisallot/"]
 tivi.fi##section > div[class] > a[href^="https://www.tivi.fi/kumppanisisallot/"]
@@ -1070,10 +1070,10 @@ tivi.fi#?#aside:has(> div > span:has-text(KAUPALLINEN YHTEISTYÖ))
 tivi.fi#?#div#skyscraper-height-div > aside > div > section > div:has-text(KAUPALLINEN YHTEISTYÖ)
 tivi.fi#?#div#skyscraper-height-div > div > aside > div > section > div:has-text(KAUPALLINEN YHTEISTYÖ)
 tivi.fi#?#div#skyscraper-height-div > section > div > a > div:has-text(Kaupallinen yhteistyö)
-tivi.fi#?#section > .lazyload-wrapper + div[class]:has(> a[href^="https://tivi.fi/kumppanisisallot/"])
+tivi.fi##section > .lazyload-wrapper + div[class]:has(> a[href^="https://tivi.fi/kumppanisisallot/"])
 toimitilat.kauppalehti.fi##.inner.sp-article
 toimitilat.kauppalehti.fi##.sponsored-article.list-article
-toimitilat.kauppalehti.fi#?#.list-article:has(.sp-tag)
+toimitilat.kauppalehti.fi##.list-article:has(.sp-tag)
 toimitilat.oikotie.fi##[analytics-impression="energy-promotion_listing-page_impression"]
 tori.fi###banner_panorama_bottom
 tori.fi###footer_partner_links
@@ -1086,8 +1086,8 @@ ts.fi##[data-readpeakurl^="https://app.readpeak.com/ads/"]
 ts.fi##div[class*="tsv3-c-common-smart noad-hideaction"]
 ts.fi#?#.tsv3-c-common-elementcollection:has-text(/yhteistyö[\u00AD]kumppanimme artikkelit/)
 ts.fi#?#.tsv3-c-common-elementlist--layout-mobiili_etusivu:has-text(/yhteistyö[\u00AD]kumppanimme artikkelit/)
-ts.fi#?#.tsv3-c-common-forum-threadviewer__messages__item:has(.smartad)
-ts.fi#?#.tsv3-c-common-twocolumnslayout:has(div[class*=element--nativead])
+ts.fi##.tsv3-c-common-forum-threadviewer__messages__item:has(.smartad)
+ts.fi##.tsv3-c-common-twocolumnslayout:has(div[class*=element--nativead])
 ts.fi#?#.tsv3-c-common-twocolumnslayout__row__right:has(.noad-hideaction-self):not(:has(.tsv3-c-ts-newstip)):not(:has(.tsv3-c-common-forum-threadlist))
 tulikulma.fi##.slideshow
 turuntienoo.fi###main > .ads
@@ -1099,16 +1099,16 @@ ulvilanseutu.fi##.adsanity-single
 ulvilanseutu.fi##.top-bar
 ulvilanseutu.fi#?#.elementor-widget-container:has-text(MAINOS)
 urjalansanomat.fi##.cat-kaupallinen-yhteistyo
-urjalansanomat.fi#?#.urjal-widget.main:has(a[href="https://urjalansanomat.fi/verkkomainonta/"])
-urjalansanomat.fi#?#.urjal-widget.main:has(a[href="https://ysiauto.fi/"])
-urjalansanomat.fi#?#.widget:has(> a[href="/lounaat"])
+urjalansanomat.fi##.urjal-widget.main:has(a[href="https://urjalansanomat.fi/verkkomainonta/"])
+urjalansanomat.fi##.urjal-widget.main:has(a[href="https://ysiauto.fi/"])
+urjalansanomat.fi##.widget:has(> a[href="/lounaat"])
 uudenkaupunginsanomat.fi###auto-grid-container-5c40764673d19
 uusisuomi.fi##[data-test=mainTeaserColumn][href^="https://www.uusisuomi.fi/kumppanisisallot/"]
 uusisuomi.fi##aside [data-test="tabs"] [href^="https://www.uusisuomi.fi/kumppanisisallot"]
 uusisuomi.fi##aside [href^="https://track.adform.net/"]
 uusisuomi.fi##aside [href^="https://www.ilmarinen.fi/"]
 uusisuomi.fi#?#.lazyload-wrapper + section:has-text(Kaupallinen yhteistyö)
-uusisuomi.fi#?#.lazyload-wrapper:has(.eo-embed-announcements-container)
+uusisuomi.fi##.lazyload-wrapper:has(.eo-embed-announcements-container)
 uusisuomi.fi#?#div#skyscraper-height-div > div > aside > section > a:has-text(Kaupallinen yhteistyö)
 uusisuomi.fi#?#div#skyscraper-height-div > div > main > div > a:has-text(Kaupallinen yhteistyö)
 uusiteknologia.fi##.widget_block
@@ -1118,7 +1118,7 @@ uutisankka.com##.uutis-footer-sticky[data-uutis-trackbid]
 v2.fi##img[src^="https://ads.v2.fi/"]:not([src$="discomainos.png"], [src$="facebookmainos.jpg"], [src$="instamainos.jpg"], [src$="twittermainos.jpg"], [src$="youtubemainos.jpg"])
 vaasalehti.fi#?#h2 > span:has-text(Mainos)
 vagarena.fi###bodyarea td[width="100%"][valign="top"] + td[valign="top"]
-valioliiga.com#?#.menu-item:has([href$="/vedonlyonti/"])
+valioliiga.com##.menu-item:has([href$="/vedonlyonti/"])
 vantaansanomat.fi##div.display-ad
 vapaasana.swedishforum.net###p0
 vapaasana.swedishforum.net##div#main-content > div:first-of-type[style="overflow:visible"]
@@ -1140,18 +1140,18 @@ verkkouutiset.fi##.vu-content-injected-middle
 verkkouutiset.fi##article.rp-lift.featured-post
 verkkouutiset.fi##section[id^="front-page-parade"]
 verkkouutiset.fi##section[id^="front_page_parade"]
-verkkouutiset.fi#?#.elementor-motion-effects-parent:has(.strossle-sidebar)
+verkkouutiset.fi##.elementor-motion-effects-parent:has(.strossle-sidebar)
 verkkouutiset.fi#?#.elementor-section-height-default.elementor-section-boxed.elementor-element.elementor-top-section.elementor-section:has(.elementor-widget-shortcode:has(.vu-adlabel))
 verkkouutiset.fi#?#article.featured-post:has-text(Mainos)
 vertaa.fi##[id|=gpt-slot-billboard]
-vertaa.fi#?#li[class^=cg-][data-role=items-list-item]:has(> div > [id^=gpt-slot-results-][id*=rectangle])
+vertaa.fi##li[class^=cg-][data-role=items-list-item]:has(> div > [id^=gpt-slot-results-][id*=rectangle])
 viikkopk.fi##.banner-mainos
 viikkopk.fi##.mobiiliylabanner
 viikkopk.fi##div[class*=artikkeliad]
 viikkopk.fi##div[class*=artikkelimainos]
 viikonloppu.com###text-8
 viikonloppu.com###text-9
-viikonloppu.com#?#.listing-item:has(> .item-inner > .native-title)
+viikonloppu.com##.listing-item:has(> .item-inner > .native-title)
 viisasraha.fi##.d-md-block.d-lg-block.d-none
 viisasraha.fi##.kumppani-artikkelit
 viisasraha.fi##div[class*=native-article] > div[class=ezrichtext-field] > p > a[href^="https://danskebank.fi/"]
@@ -1165,7 +1165,7 @@ viranomaisuutiset.fi##[href^="https://in.matsmart.fi/t/"]
 viranomaisuutiset.fi##[href^="https://track.adtraction.com/"]
 viranomaisuutiset.fi##div[id|=nm-300x300]
 viranomaisuutiset.fi#?#.td-footer-wrap .td-block-row:has-text(-Yhteistyössä-)
-viranomaisuutiset.fi#?#.td-footer-wrap .td_block_title:has(+ .td-a-rec)
+viranomaisuutiset.fi##.td-footer-wrap .td_block_title:has(+ .td-a-rec)
 viranomaisuutiset.fi#?#div[id|=polii]:has([id|=nm-300x300] + br + br)
 voice.fi##.article-sponsored
 voice.fi##a[class="article-item articlestream-item unloaded"][data-sponsored="1"]
@@ -1179,11 +1179,11 @@ webnode.fi##.wnd-free-stripe-link
 wizhdsports.fi##.widget_media_image
 www.io-tech.fi###text-7
 www.io-tech.fi##aside.jimmx
-www.io-tech.fi#?#.artikkeli-slide:has(img[src*="-nostokuva"])
-www.io-tech.fi#?#.artikkeli-slide:has(img[src*="Ad-otsikko"])
-www.io-tech.fi#?#.artikkeli-slide:has(img[src*="mainos"])
-www.io-tech.fi#?#.artikkeli-slide:has(img[src*="natiivi-otsikko"])
-www.io-tech.fi#?#.view-full.uutinen:has(a[href="https://www.io-tech.fi/category/mainos/"])
+www.io-tech.fi##.artikkeli-slide:has(img[src*="-nostokuva"])
+www.io-tech.fi##.artikkeli-slide:has(img[src*="Ad-otsikko"])
+www.io-tech.fi##.artikkeli-slide:has(img[src*="mainos"])
+www.io-tech.fi##.artikkeli-slide:has(img[src*="natiivi-otsikko"])
+www.io-tech.fi##.view-full.uutinen:has(a[href="https://www.io-tech.fi/category/mainos/"])
 www.nettiauto.com###article_box li:has([id|="almad-post-content"])
 www.nettiauto.com,www.nettikaravaani.com,www.nettikone.com,www.nettimokki.com,www.nettimoto.com,www.nettivaraosa.com,www.nettivene.com,www.nettivuokraus.com###homeBottomBoxBanner
 www.nettiauto.com,www.nettikaravaani.com,www.nettikone.com,www.nettimokki.com,www.nettimoto.com,www.nettivaraosa.com,www.nettivene.com,www.nettivuokraus.com###homeTopBoxBanner
@@ -1203,10 +1203,10 @@ www.nettivene.com#?#.article-blocks__item:has(> .block-row > [id|="almad-post-co
 www.nettivene.com#?#.grid-x.cell:has(> #banner-container-HomePageBanner > [id|="almad-content"])
 www.suomi24.fi##.asp
 www.suomi24.fi##div[class^=Vaalikone__HeaderAdWrapper]
-www.suomi24.fi#?#div[class^="HomePage__RightColItem"]:has(> div[class^="AdLivewrapped__AdWrapper"])
-www.suomi24.fi#?#div[class^="HomePage__RightColItem"]:has(> div[class^="Lainavertailu__Container"])
-www.suomi24.fi#?#p:has(+ p + .asp)
-www.uusisuomi.fi#?#.lazyload-wrapper:has(.at-embed-container)
+www.suomi24.fi##div[class^="HomePage__RightColItem"]:has(> div[class^="AdLivewrapped__AdWrapper"])
+www.suomi24.fi##div[class^="HomePage__RightColItem"]:has(> div[class^="Lainavertailu__Container"])
+www.suomi24.fi##p:has(+ p + .asp)
+www.uusisuomi.fi##.lazyload-wrapper:has(.at-embed-container)
 www.uusisuomi.fi#?#aside > section:has-text(Kaupallinen yhteistyö)
 www.uusisuomi.fi#?#body:not(.is-style-kumppanisisallot) main > div[class]:has-text(Kaupallinen yhteistyö)
 www.uusisuomi.fi#?#div[width]:has(> [id|="almad-parade"])
@@ -1218,22 +1218,22 @@ ykkoslohja.fi##.bfastmag-a-d-v
 ykkoslohja.fi##a[href="https://ostalohjalta.fi"]
 ykkoslohja.fi##a[href="https://ostavihdista.fi"]
 ykkoslohja.fi#?##sidebar-widgets-area-1 > .widget:has-text(Mainos)
-ykkoslohja.fi#?#.widget:has([href^="http://pizza-online.fi/tt/"])
-ykkoslohja.fi#?#.widget:has([href^="https://c.trackmytarget.com?"])
-ykkoslohja.fi#?#.widget:has([href^="https://kauppa.latvala.com"])
-ykkoslohja.fi#?#.widget:has([href^="https://med.etoro.com/"])
-ykkoslohja.fi#?#.widget:has([href^="https://tc.tradetracker.net/"])
-ykkoslohja.fi#?#.widget:has([href^="https://track.adtraction.com/"])
-ykkoslohja.fi#?#.widget:has([href^="https://www.awin1.com/"])
-ykkoslohja.fi#?#.widget:has([href^="https://www.kahvivertailu.fi"])
-ykkoslohja.fi#?#.widget:has([rel="sponsored"])
-ykkoslohja.fi#?#.widget:has([src^="https://track.adtraction.com/"])
+ykkoslohja.fi##.widget:has([href^="http://pizza-online.fi/tt/"])
+ykkoslohja.fi##.widget:has([href^="https://c.trackmytarget.com?"])
+ykkoslohja.fi##.widget:has([href^="https://kauppa.latvala.com"])
+ykkoslohja.fi##.widget:has([href^="https://med.etoro.com/"])
+ykkoslohja.fi##.widget:has([href^="https://tc.tradetracker.net/"])
+ykkoslohja.fi##.widget:has([href^="https://track.adtraction.com/"])
+ykkoslohja.fi##.widget:has([href^="https://www.awin1.com/"])
+ykkoslohja.fi##.widget:has([href^="https://www.kahvivertailu.fi"])
+ykkoslohja.fi##.widget:has([rel="sponsored"])
+ykkoslohja.fi##.widget:has([src^="https://track.adtraction.com/"])
 ykkoslohja.fi#?#.widget:has(h2:only-child):has(+ .widget [href^="https://c.trackmytarget.com?"])
 ykkoslohja.fi#?#.widget:has(h2:only-child):has(+ .widget [href^="https://www.awin1.com/"])
 ykkoslohja.fi#?#.widget:has(h2:only-child):has(+ .widget [src^="https://track.adtraction.com/"])
 ykkoslohja.fi#?#.widget:has-text(tradedoubler.com)
 ykkoslohja.fi#?#.widget_carousel_slider:has-text(tarjouksia tälle viikolle)
-ykkoslohja.fi#?#.wp-block-columns:has([href^="https://c.trackmytarget.com?"])
+ykkoslohja.fi##.wp-block-columns:has([href^="https://c.trackmytarget.com?"])
 ykkoslohja.fi#?#div[id|=block]:has-text(/Lainavertailu/i)
 ykkoslohja.fi#?#div[id|=block]:has-text(eToro)
 ylasatakunta.fi##.ad[class*=panorama]
@@ -1242,7 +1242,7 @@ ylasatakunta.fi##.ad[class*=ylaboksi]
 ylasatakunta.fi##.tarranurkka
 ylasatakunta.fi##a[href^="/artikkeli-kaupallinen-"]
 ylasatakunta.fi#?#.ad:not(:has(img[src*="doc_id=555723"])):not(:has(img[src*="doc_id=553464"]))
-ylojarvenuutiset.fi#?#.widget:has(.mainossidebar)
+ylojarvenuutiset.fi##.widget:has(.mainossidebar)
 yrittajat.fi##.b-area-ad-sidebar
 yrittajat.fi##.b-otavamedia-ads
 yrittajat.fi##.gb-otavamedia-ad
@@ -1402,30 +1402,30 @@ iltalehti.fi##[class|="almad-mobile-parade"]
 iltalehti.fi##div.footer-wrapper__item.is-visible.LazyLoad
 iltalehti.fi##div[class=iframe-container]
 iltalehti.fi#?#.card .recommendation:has-text(Kaupallinen yhteistyö)
-iltalehti.fi#?#.card:has(#il-rantapallo-right-column-box)
-iltalehti.fi#?#.card:has(.alennuskoodi-column-embed)
-iltalehti.fi#?#.card:has(.etua-widget-container)
-iltalehti.fi#?#.card:has(.etuovi-react-embed)
+iltalehti.fi##.card:has(#il-rantapallo-right-column-box)
+iltalehti.fi##.card:has(.alennuskoodi-column-embed)
+iltalehti.fi##.card:has(.etua-widget-container)
+iltalehti.fi##.card:has(.etuovi-react-embed)
 iltalehti.fi#?#.category-double-article-container:has(.half-article:nth-child(1):has-text(Kaupallinen yhteistyö) + .half-article:nth-child(2):has-text(Kaupallinen yhteistyö))
-iltalehti.fi#?#.embed-placeholder:has(> div > .eo-embed-announcements-container.card)
+iltalehti.fi##.embed-placeholder:has(> div > .eo-embed-announcements-container.card)
 iltalehti.fi#?#.related-articles-list > .link-container:has-text(/^Kaupallinen yhteistyö/)
-iltalehti.fi#?#.side-column-content .card:has(.nettiauto-sponsored-content-text)
-iltalehti.fi#?#a.articles__list-item[href^="/telkku/"]:has(p.articles__sponsored-banner)
+iltalehti.fi##.side-column-content .card:has(.nettiauto-sponsored-content-text)
+iltalehti.fi##a.articles__list-item[href^="/telkku/"]:has(p.articles__sponsored-banner)
 iltalehti.fi#?#a.small-article:has-text(Kaupallinen yhteistyö)
 iltalehti.fi#?#div.card:has-text(Mainos:)
-iltalehti.fi#?#div.fp-container.card:has([href*=clark-taloutesi-tukena])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src*=KAUPALLINEN][src*=YHTEISTY])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src*=kaupallinenyht i])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src^=ky- i])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src^=ky_ i])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src*=kyi_ i])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi"][src*=mainos i])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi/Nauha_Rantapallo"])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi/asuminen_vattenfall_palkki"])
-iltalehti.fi#?#div.fp-container.card:has([src*="ilcdn.fi/kuvat/nauhat/nauha_terveys_specsavers"])
+iltalehti.fi##div.fp-container.card:has([href*=clark-taloutesi-tukena])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src*=KAUPALLINEN][src*=YHTEISTY])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src*=kaupallinenyht i])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src^=ky- i])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src^=ky_ i])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src*=kyi_ i])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi"][src*=mainos i])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/Nauha_Rantapallo"])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/asuminen_vattenfall_palkki"])
+iltalehti.fi##div.fp-container.card:has([src*="ilcdn.fi/kuvat/nauhat/nauha_terveys_specsavers"])
 iltalehti.fi#?#div.fp-container.card:has-text(Kaupallinen yhteistyö)
 iltalehti.fi#?#div.is-visible.LazyLoad:has-text(kaupallinen yhteistyö)
-iltalehti.fi#?#div[class="card "]:has(.block > a[class=nakoislehti][href^="https://plus.iltalehti.fi/nakoislehti/"])
+iltalehti.fi##div[class="card "]:has(.block > a[class=nakoislehti][href^="https://plus.iltalehti.fi/nakoislehti/"])
 iltalehti.fi#?#div[class="card "]:has(> .block > div[class=content-router-wrapper]:has-text(kaupallinen yhteistyö))
 
 iltalehti.fi#?#div.container:not(.sub-category-unikulma):not(.sub-category-rahapuhe):not(.sub-category-santander):not(.sub-category-miehen-terveys):not(.sub-category-kehon-hyvinvointi-ja-vitaepro):not(.sub-category-unijaterveys):not(.sub-category-huippukivaa-seksia):not(.sub-category-puhti):not(.sub-category-hyvinvointivinkit):not(.sub-category-hetki):not(.sub-category-kaalimato):not(.sub-category-oslo-skin-lab):not(.sub-category-kodin-siivousvinkit):not(.sub-category-qled-tv):not(.sub-category-jatevesiratkaisut):not(.sub-category-bluestep):not(.sub-category-sortter-reilua-lainavertailua):not(.sub-category-rahalaitos):not(.sub-category-aitien-keittiosta):not(.sub-category-koko-kansan-autokauppa):not(.sub-category-kuljetusten-kestava-kehitys):not(.sub-category-kestavat-liikkuvuusratkaisut):not(.sub-category-hintaopas):not(.sub-category-boltworks):not(.sub-category-samsung-tv):not(.sub-category-reseptit):not(.sub-category-terveystalo):not(.sub-category-etuafi-lainanottajan-asialla):not(.sub-category-vinkit-yrityslainaan) .article-list a[href]:has-text(Kaupallinen yhteistyö)
@@ -1470,7 +1470,7 @@ gamereactor.fi##.wrapper
 gamereactor.fi##[class^=ad_mobileLeader]
 gamereactor.fi##[class^=ad_smartphbig]
 gamereactor.fi##div[style$="color: lightgrey; font-size: 11px; text-transform: uppercase;"]
-kotiliesi.fi#?#.article-card-grid li:has(div[id^=dfp__])
+kotiliesi.fi##.article-card-grid li:has(div[id^=dfp__])
 tori.fi##.appnexus-container
 !#endif
 


### PR DESCRIPTION
I received an E-mail from Eyeo's filter development teams on 12 January that took me by surprise, as it represented and strongly recommended a *dramatic* change in ABP's official syntax policies, with the logic behind it being that all major browsers had adopted native `:has` CSS, with Firefox adopting it 4 weeks ago.

Long story short: `#?#` + `:has` are now strongly recommended to be changed to `##` + `:has`, as long as there is **no** `:has-text` stuff in the same entry.

I could forward the E-mail to one or more of you guys at Team Finnish Easylist Addition, but I don't think it'd be needed. Neither AdGuard nor uBO have made similar announcements based on browser CSS support yet, so I'll leave any discretion about this PR to you guys.