### PR TITLE
Partly address https://github.com/DandelionSprout/adfilt/issues/1083

### DIFF
--- a/Finland_adb.txt
+++ b/Finland_adb.txt
@@ -1344,7 +1344,7 @@ _300x300_*.mp4$media,domain=futisfani.com|kiekkofani.com|penkkiurheilu.com|uutis
 ||laitilansanomat.fi^*/gallery/mainos*/$image,domain=laitilansanomat.fi
 ||lbaanijakuva.fi/test/*?template=prisjakt$domain=lbaanijakuva.fi
 ||m.riemurasia.net/reklaami.php$subdocument,domain=m.riemurasia.net
-||matkaendurot.net/images/*banner,domain=matkaendurot.net
+||matkaendurot.net/images/*banner$domain=matkaendurot.net
 ||med.etoro.com^$domain=ykkoslohja.fi
 ||media.power-cdn.net/images/pages/orderpage/*-power-huippudiili-*.jpg$image
 ||media.vuokraovi.com^$third-party


### PR DESCRIPTION
On line 1347, there is a comma instead of a dollar sign in the filter `||matkaendurot.net/images/*banner,domain=matkaendurot.net`, resulting in an invalid filter. I have corrected this minor error.
This was reported in https://github.com/DandelionSprout/adfilt/issues/1083.
Thank you